### PR TITLE
Handle empty 2xx responses without JSON parse failures

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -44,6 +44,29 @@ impl ClickUpClient {
         }
     }
 
+    async fn parse_success_response(
+        resp: reqwest::Response,
+        status: u16,
+    ) -> Result<serde_json::Value, CliError> {
+        if status == 204 {
+            return Ok(serde_json::json!({}));
+        }
+
+        let body_text = resp.text().await.map_err(|e| CliError::ClientError {
+            message: format!("Failed to read response body: {}", e),
+            status,
+        })?;
+
+        if body_text.trim().is_empty() {
+            return Ok(serde_json::json!({}));
+        }
+
+        serde_json::from_str(&body_text).map_err(|e| CliError::ClientError {
+            message: format!("Failed to parse response: {}", e),
+            status,
+        })
+    }
+
     async fn request(
         &self,
         method: reqwest::Method,
@@ -73,15 +96,7 @@ impl ClickUpClient {
             self.update_rate_limits(resp.headers());
 
             if (200..300).contains(&status) {
-                if status == 204 {
-                    return Ok(serde_json::json!({}));
-                }
-                let json: serde_json::Value =
-                    resp.json().await.map_err(|e| CliError::ClientError {
-                        message: format!("Failed to parse response: {}", e),
-                        status,
-                    })?;
-                return Ok(json);
+                return Self::parse_success_response(resp, status).await;
             }
 
             // Retry on 429 — wait for rate limit reset, retry once
@@ -207,14 +222,7 @@ impl ClickUpClient {
         self.update_rate_limits(resp.headers());
 
         if (200..300).contains(&status) {
-            if status == 204 {
-                return Ok(serde_json::json!({}));
-            }
-            let json: serde_json::Value = resp.json().await.map_err(|e| CliError::ClientError {
-                message: format!("Failed to parse response: {}", e),
-                status,
-            })?;
-            return Ok(json);
+            return Self::parse_success_response(resp, status).await;
         }
 
         let body_text = resp.text().await.unwrap_or_default();


### PR DESCRIPTION
## Summary

This fixes a client-side parse failure when ClickUp returns a successful `2xx` response with an empty body. It showed up on `doc edit-page`, where the API returned `HTTP 200` with `content-length: 0` and the CLI incorrectly tried to parse JSON.

Fixes #10

## Changes

- add shared success-response handling that treats empty successful response bodies as `{}` instead of forcing JSON parsing
- use that shared handling in the main request path and upload path

## Testing

- [x] `cargo test` passes
- [x] `cargo fmt --all --check` passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [x] Manually verified (explain how):
  Reproduced the failure with `clickup doc edit-page` against a real ClickUp doc page where the API returned `HTTP 200` with an empty body. Before the patch, the CLI failed with `Failed to parse response: error decoding response body`. After the patch, the same command succeeds and returns `{}`.

## Notes

The root cause is that the client assumed every successful non-`204` response contained JSON. ClickUp’s doc page edit endpoint can return success with an empty body, so the client needs to treat empty successful responses as valid.