### PR TITLE
Expose custom field option IDs in `clickup_field_list`

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,7 +176,7 @@ clickup view tasks VIEW_ID
 # Tags and custom fields
 clickup tag list --space 12345
 clickup field list --list 12345
-clickup field set TASK_ID FIELD_ID --value "some value"
+clickup field set FIELD_ID --value "some value" TASK_ID
 
 # Chat (v3)
 clickup chat channel-list

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -249,11 +249,11 @@ Custom fields on tasks.
 
 ```bash
 clickup field list --list <ID>            # also --folder, --space, --workspace-level
-clickup field set <TASK_ID> <FIELD_ID> --value VALUE
-clickup field unset <TASK_ID> <FIELD_ID>
+clickup field set <FIELD_ID> --value VALUE [TASK_ID]
+clickup field unset <FIELD_ID> [TASK_ID]
 ```
 
-Value can be a string, number, or JSON for complex field types.
+Value can be a string, number, or JSON for complex field types. For `drop_down`, use the option ID from the field's `type_config.options`; for `labels`, pass a JSON array of option IDs.
 
 ---
 

--- a/src/commands/field.rs
+++ b/src/commands/field.rs
@@ -28,7 +28,7 @@ pub enum FieldCommands {
     Set {
         /// Field ID
         field_id: String,
-        /// Field value (string, number, or JSON)
+        /// Field value (string, number, or JSON; use the option ID for drop_down fields)
         #[arg(long)]
         value: String,
         /// Task ID (auto-detected from git branch if omitted)

--- a/src/mcp.rs
+++ b/src/mcp.rs
@@ -1,6 +1,6 @@
 use crate::client::ClickUpClient;
 use crate::config::Config;
-use crate::output::compact_items;
+use crate::output::{compact_items, flatten_value};
 use serde_json::{json, Value};
 use tokio::io::{AsyncBufReadExt, BufReader};
 
@@ -264,7 +264,7 @@ pub fn tool_list() -> Value {
         },
         {
             "name": "clickup_field_list",
-            "description": "List the custom field definitions available on a ClickUp list — field id, name, type (text, number, dropdown, labels, date, url, email, phone, money, progress, formula, etc.), and for dropdown/labels fields the permitted option values. Use this before clickup_field_set to learn the correct field_id and value shape. Returns an array of custom field definitions.",
+            "description": "List the custom field definitions available on a ClickUp list — field id, name, type (text, number, drop_down, labels, date, url, email, phone, money, progress, formula, etc.), and for drop_down/labels fields the permitted option values extracted from type_config.options. Use this before clickup_field_set to learn the correct field_id, option ids, and value shape. Returns an array of custom field definitions.",
             "inputSchema": {
                 "type": "object",
                 "properties": {
@@ -275,13 +275,13 @@ pub fn tool_list() -> Value {
         },
         {
             "name": "clickup_field_set",
-            "description": "Set or overwrite a single custom field value on a ClickUp task. The value's JSON shape must match the field type (string for text/url/email, number for number/currency/progress, array of option ids for dropdown/labels, Unix ms for date, etc.). Use clickup_field_list first to see the field type and option ids. Use clickup_field_unset to clear a value. Returns an empty object on success.",
+            "description": "Set or overwrite a single custom field value on a ClickUp task. The value's JSON shape must match the field type (string for text/url/email and for a drop_down option id, number for number/currency/progress, array of option ids for labels, Unix ms for date, etc.). Use clickup_field_list first to see the field type and option ids. Use clickup_field_unset to clear a value. Returns an empty object on success.",
             "inputSchema": {
                 "type": "object",
                 "properties": {
                     "task_id": {"type": "string", "description": "ID of the task whose field value should change. Obtain from clickup_task_list (field: id)."},
                     "field_id": {"type": "string", "description": "ID of the custom field to set. Obtain from clickup_field_list (field: id) or clickup_task_get (custom_fields[].id)."},
-                    "value": {"description": "New value; the accepted type depends on the custom field type. Examples: 'hello' (text), 42 (number), ['option-uuid'] (dropdown), 1735689600000 (date as Unix ms). See clickup_field_list for the field's type."}
+                    "value": {"description": "New value; the accepted type depends on the custom field type. Examples: 'hello' (text), 42 (number), 'option-uuid' (drop_down), ['option-uuid'] (labels), 1735689600000 (date as Unix ms). See clickup_field_list for the field's type and option ids."}
                 },
                 "required": ["task_id", "field_id", "value"]
             }
@@ -1973,6 +1973,35 @@ pub fn filtered_tool_list(filter: &filter::Filter) -> serde_json::Value {
     serde_json::Value::Array(filtered)
 }
 
+/// Compact custom field definitions while preserving option IDs for fields
+/// whose possible values live in `type_config.options`.
+pub fn compact_custom_fields(fields: &[Value]) -> Value {
+    let compacted: Vec<Value> = fields
+        .iter()
+        .map(|field| {
+            let mut obj = serde_json::Map::new();
+            for key in ["id", "name", "type", "required"] {
+                obj.insert(
+                    key.to_string(),
+                    Value::String(flatten_value(field.get(key))),
+                );
+            }
+
+            if let Some(options) = field
+                .get("type_config")
+                .and_then(|config| config.get("options"))
+                .and_then(|options| options.as_array())
+            {
+                obj.insert("options".to_string(), Value::Array(options.clone()));
+            }
+
+            Value::Object(obj)
+        })
+        .collect();
+
+    Value::Array(compacted)
+}
+
 // ── Tool execution ────────────────────────────────────────────────────────────
 
 async fn call_tool(
@@ -2345,7 +2374,7 @@ async fn dispatch_tool(
                 .and_then(|f| f.as_array())
                 .cloned()
                 .unwrap_or_default();
-            Ok(compact_items(&fields, &["id", "name", "type", "required"]))
+            Ok(compact_custom_fields(&fields))
         }
 
         "clickup_field_set" => {

--- a/tests/test_mcp_fields.rs
+++ b/tests/test_mcp_fields.rs
@@ -1,0 +1,72 @@
+use clickup_cli::mcp::compact_custom_fields;
+use serde_json::json;
+
+#[test]
+fn compact_custom_fields_promotes_type_config_options() {
+    let fields = vec![json!({
+        "id": "e61c8995",
+        "name": "Stage",
+        "type": "drop_down",
+        "required": false,
+        "type_config": {
+            "options": [
+                {
+                    "id": "option-1",
+                    "name": "Ready",
+                    "color": "#2ecd6f",
+                    "orderindex": 0
+                },
+                {
+                    "id": "option-2",
+                    "name": "Blocked",
+                    "color": "#e50000",
+                    "orderindex": 1
+                }
+            ]
+        }
+    })];
+
+    let result = compact_custom_fields(&fields);
+
+    assert_eq!(result[0]["id"], json!("e61c8995"));
+    assert_eq!(result[0]["type"], json!("drop_down"));
+    assert_eq!(result[0]["required"], json!("false"));
+    assert_eq!(result[0]["options"][0]["id"], json!("option-1"));
+    assert_eq!(result[0]["options"][0]["name"], json!("Ready"));
+    assert_eq!(result[0]["options"][1]["id"], json!("option-2"));
+}
+
+#[test]
+fn compact_custom_fields_omits_options_when_type_config_has_no_options() {
+    let fields = vec![json!({
+        "id": "text-field",
+        "name": "Notes",
+        "type": "text",
+        "required": true,
+        "type_config": {}
+    })];
+
+    let result = compact_custom_fields(&fields);
+
+    assert_eq!(result[0]["id"], json!("text-field"));
+    assert_eq!(result[0]["type"], json!("text"));
+    assert_eq!(result[0]["required"], json!("true"));
+    assert!(result[0].get("options").is_none());
+}
+
+#[test]
+fn compact_custom_fields_keeps_empty_options_array() {
+    let fields = vec![json!({
+        "id": "labels-field",
+        "name": "Labels",
+        "type": "labels",
+        "required": false,
+        "type_config": {
+            "options": []
+        }
+    })];
+
+    let result = compact_custom_fields(&fields);
+
+    assert_eq!(result[0]["options"], json!([]));
+}


### PR DESCRIPTION
<!--
Thanks for contributing. See CONTRIBUTING.md for the full flow.
Quick version: link the issue, describe the change, show you tested it.
-->

## Summary

`clickup_field_list` currently returns basic custom field metadata but drops `type_config`, which means `drop_down` and `labels` fields do not include their allowed values. That makes the MCP tool incomplete for setting custom fields: ClickUp expects option IDs, not labels, when calling `clickup_field_set`.

Fixes #12

## Changes

- Extracts `type_config.options` from custom field definitions returned by ClickUp.
- Promotes those values to a top-level `options` array in the `clickup_field_list` MCP response.
- Preserves option IDs, names, colors, and ordering data so agents can choose the correct value to send.
- Updates MCP descriptions to distinguish `drop_down` values from `labels` values.
- Corrects CLI docs/examples for `field set` argument order and documents option-ID usage.
- Adds tests for fields with populated options, empty options, and no options.

## Testing

- [x] `cargo test` passes
- [x] `cargo fmt --all --check` passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [x] Manually verified (explain how):

Used in my own project

## Notes

This does not attempt to create or modify ClickUp dropdown options. The ClickUp API only supports reading those options from field configuration and using the returned option IDs when setting field values.