### PR TITLE
fix: render markdown in task descriptions (#22)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- `task create --description` and `task update --description` (and the `clickup_task_create` / `clickup_task_update` MCP tools) now render markdown in the ClickUp UI (#22). The CLI was sending the plain-text `description` API field, which doesn't interpret markdown; switched to `markdown_content`, ClickUp's documented markdown-rendering field. Plain-text descriptions still display identically. User-facing flag and MCP schema parameter name (`description`) are unchanged.
+
 ## [0.9.1] - 2026-04-23
 
 ### Fixed

--- a/src/commands/task.rs
+++ b/src/commands/task.rs
@@ -410,7 +410,7 @@ pub async fn execute(command: TaskCommands, cli: &Cli) -> Result<(), CliError> {
         } => {
             let mut body = serde_json::json!({ "name": name });
             if let Some(d) = description {
-                body["description"] = serde_json::Value::String(d);
+                body["markdown_content"] = serde_json::Value::String(d);
             }
             if let Some(s) = status {
                 body["status"] = serde_json::Value::String(s);
@@ -461,7 +461,7 @@ pub async fn execute(command: TaskCommands, cli: &Cli) -> Result<(), CliError> {
                 body.insert("priority".into(), serde_json::json!(p));
             }
             if let Some(d) = description {
-                body.insert("description".into(), serde_json::Value::String(d));
+                body.insert("markdown_content".into(), serde_json::Value::String(d));
             }
             // Assignee add/remove uses nested object
             if add_assignee.is_some() || rem_assignee.is_some() {

--- a/src/mcp.rs
+++ b/src/mcp.rs
@@ -2367,7 +2367,7 @@ async fn dispatch_tool(
                 .ok_or("Missing required parameter: name")?;
             let mut body = json!({"name": name});
             if let Some(desc) = args.get("description").and_then(|v| v.as_str()) {
-                body["description"] = json!(desc);
+                body["markdown_content"] = json!(desc);
             }
             if let Some(status) = args.get("status").and_then(|v| v.as_str()) {
                 body["status"] = json!(status);
@@ -2408,7 +2408,7 @@ async fn dispatch_tool(
                 body["priority"] = json!(priority);
             }
             if let Some(desc) = args.get("description").and_then(|v| v.as_str()) {
-                body["description"] = json!(desc);
+                body["markdown_content"] = json!(desc);
             }
             if let Some(add) = args.get("add_assignees") {
                 body["assignees"] = json!({"add": add, "rem": args.get("rem_assignees").cloned().unwrap_or(json!([]))});


### PR DESCRIPTION
## Summary
- Switch the body field used by `task create` / `task update` (CLI and MCP) from `description` to `markdown_content`, ClickUp's documented markdown-rendering field.
- Plain-text descriptions are unaffected since plain prose renders identically as markdown.
- User-facing CLI flag (`--description`) and MCP schema parameter name (`description`) are unchanged. Only the API body field name changes.
- CHANGELOG entry added under `[Unreleased]`.

Fixes #22.

## Test plan
- [x] `cargo test`: 112/112 pass across 12 suites
- [x] `cargo clippy -- -D warnings`: clean
- [x] Manual smoke against the live API. Created a throwaway list, ran `task create` and `task update` with markdown bodies (headings, bold, italic, code, bullet/numbered lists, blockquotes, links), then fetched the task back. The stored `description` field came back with all markdown markup stripped (asterisks, hashes, list markers removed), confirming ClickUp parsed the input as markdown rather than treating it literally. List and task decommissioned after the test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
