### PR TITLE
docs: correct MCP and CLI strings that lied about API behaviour

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - `task create --description` and `task update --description` (and the `clickup_task_create` / `clickup_task_update` MCP tools) now render markdown in the ClickUp UI (#22). The CLI was sending the plain-text `description` API field, which doesn't interpret markdown; switched to `markdown_content`, ClickUp's documented markdown-rendering field. Plain-text descriptions still display identically. User-facing flag and MCP schema parameter name (`description`) are unchanged.
 
+### Changed
+- CLI help and MCP tool descriptions corrected after an audit against ClickUp's official OpenAPI spec. No behaviour change; documentation only.
+  - `comment create`, `comment update`, `comment reply` (and the corresponding `clickup_comment_*` MCP tools) no longer claim markdown support. ClickUp's v2 comment API only accepts plain `comment_text` and renders neither markdown nor rich text; markdown syntax is stored verbatim. @mentions are still rendered.
+  - `clickup_doc_create` MCP `parent.type` cheat sheet corrected: the enum is 4=space, 5=folder, 6=list, 7=everything, 12=workspace. The previous text said 7=task, which is wrong.
+  - `clickup_webhook_delete` MCP description: the alternative-to-delete suggestion now points at `status='inactive'`. The previous text said `'suspended'`, which is not a value the API accepts.
+  - `clickup_audit_log_query` MCP `type` parameter description: corrected example enum values to ClickUp's actual categories (AUTH, HIERARCHY, USER, CUSTOM_FIELDS, AGENT, OTHER). The previous text invented `task_created`, `user_added`, `permission_changed`.
+  - `clickup_chat_channel_update` MCP `description` field no longer claims markdown support; ClickUp's chat-channel description field is plain text.
+
 ## [0.9.1] - 2026-04-23
 
 ### Fixed

--- a/src/commands/comment.rs
+++ b/src/commands/comment.rs
@@ -31,7 +31,7 @@ pub enum CommentCommands {
         /// View ID
         #[arg(long, conflicts_with_all = ["task", "list"])]
         view: Option<String>,
-        /// Comment text
+        /// Comment text. Note: ClickUp's v2 comment API does not render markdown; markdown syntax is stored as literal text.
         #[arg(long)]
         text: String,
         /// Assignee user ID (task comments only)
@@ -45,7 +45,7 @@ pub enum CommentCommands {
     Update {
         /// Comment ID
         id: String,
-        /// New comment text
+        /// New comment text. Note: ClickUp's v2 comment API does not render markdown; markdown syntax is stored as literal text.
         #[arg(long)]
         text: String,
         /// Mark as resolved
@@ -69,7 +69,7 @@ pub enum CommentCommands {
     Reply {
         /// Comment ID
         id: String,
-        /// Reply text
+        /// Reply text. Note: ClickUp's v2 comment API does not render markdown; markdown syntax is stored as literal text.
         #[arg(long)]
         text: String,
         /// Assignee user ID

--- a/src/mcp.rs
+++ b/src/mcp.rs
@@ -404,12 +404,12 @@ pub fn tool_list() -> Value {
         },
         {
             "name": "clickup_comment_create",
-            "description": "Post a new top-level comment on a ClickUp task. Supports markdown and @mentions in the text body. Returns the created comment object including its new id, which you can pass to clickup_comment_reply, clickup_comment_update, etc.",
+            "description": "Post a new top-level comment on a ClickUp task. @mentions are recognised by ClickUp. Note: ClickUp's v2 comment API stores the body verbatim and does NOT render markdown. Tokens like `**bold**` appear as literal characters in the UI. Returns the created comment object including its new id, which you can pass to clickup_comment_reply, clickup_comment_update, etc.",
             "inputSchema": {
                 "type": "object",
                 "properties": {
                     "task_id": {"type": "string", "description": "ID of the task to comment on. Obtain from clickup_task_list (field: id) or clickup_task_search."},
-                    "text": {"type": "string", "description": "Comment body. Markdown and @mentions (e.g. '@username') are supported."},
+                    "text": {"type": "string", "description": "Comment body. @mentions (e.g. '@username') are rendered. Markdown is NOT rendered by ClickUp's v2 comment API. Markdown syntax is stored as literal text."},
                     "assignee": {"type": "integer", "description": "Optional user ID to assign the comment to — they will receive a notification. Obtain from clickup_member_list."},
                     "notify_all": {"type": "boolean", "description": "true = send a notification to every assignee of the task; false or omitted = only notify people mentioned or the explicit assignee."}
                 },
@@ -868,7 +868,7 @@ pub fn tool_list() -> Value {
                 "type": "object",
                 "properties": {
                     "comment_id": {"type": "string", "description": "ID of the comment to edit. Obtain from clickup_comment_list (field: id)."},
-                    "text": {"type": "string", "description": "Replacement body for the comment. ClickUp accepts markdown plus @mentions (e.g. '@username'). The previous body is overwritten entirely."},
+                    "text": {"type": "string", "description": "Replacement body for the comment. @mentions (e.g. '@username') are rendered. Markdown is NOT rendered by ClickUp's v2 comment API; markdown syntax is stored as literal text. The previous body is overwritten entirely."},
                     "assignee": {"type": "integer", "description": "Reassign the comment to this user ID, who will receive a notification. Obtain from clickup_member_list."},
                     "resolved": {"type": "boolean", "description": "true = mark the comment thread resolved/closed; false = reopen it."}
                 },
@@ -1104,7 +1104,7 @@ pub fn tool_list() -> Value {
                 "properties": {
                     "team_id": {"type": "string", "description": "Workspace (team) ID. Obtain from clickup_workspace_list (field: id). Omit to use the default workspace from config."},
                     "name": {"type": "string", "description": "Display name for the doc (shown in the doc tree)."},
-                    "parent": {"type": "object", "description": "Optional parent object to attach the doc under. Shape: { 'id': '<id>', 'type': <int> } where type is 4=space, 5=folder, 6=list, 7=task. Omit to create at the workspace root."}
+                    "parent": {"type": "object", "description": "Optional parent object to attach the doc under. Shape: { 'id': '<id>', 'type': <int> } where type is 4=space, 5=folder, 6=list, 7=everything, 12=workspace. Omit to create at the workspace root."}
                 },
                 "required": ["name"]
             }
@@ -1175,7 +1175,7 @@ pub fn tool_list() -> Value {
                     "team_id": {"type": "string", "description": "Workspace (team) ID. Omit to use the default workspace from config."},
                     "channel_id": {"type": "string", "description": "ID of the channel to update. Obtain from clickup_chat_channel_list (field: id)."},
                     "name": {"type": "string", "description": "New display name for the channel. Must be unique within the workspace."},
-                    "description": {"type": "string", "description": "New channel description/topic shown in the channel header. Markdown supported."}
+                    "description": {"type": "string", "description": "New channel description shown in the channel header."}
                 },
                 "required": ["channel_id"]
             }
@@ -1284,7 +1284,7 @@ pub fn tool_list() -> Value {
         },
         {
             "name": "clickup_webhook_delete",
-            "description": "Permanently delete a ClickUp webhook, stopping all future event deliveries to its endpoint. Destructive and irreversible — the webhook record is removed immediately. If you only want to pause deliveries, use clickup_webhook_update with status='suspended' instead. Returns an empty object on success.",
+            "description": "Permanently delete a ClickUp webhook, stopping all future event deliveries to its endpoint. Destructive and irreversible: the webhook record is removed immediately. If you only want to pause deliveries, use clickup_webhook_update with status='inactive' instead. Returns an empty object on success.",
             "inputSchema": {
                 "type": "object",
                 "properties": {
@@ -1624,7 +1624,7 @@ pub fn tool_list() -> Value {
                 "type": "object",
                 "properties": {
                     "comment_id": {"type": "string", "description": "ID of the parent comment to reply to. Obtain from clickup_comment_list (field: id)."},
-                    "text": {"type": "string", "description": "Reply body. Markdown and @mentions supported."},
+                    "text": {"type": "string", "description": "Reply body. @mentions are rendered. Markdown is NOT rendered by ClickUp's v2 comment API; markdown syntax is stored as literal text."},
                     "assignee": {"type": "integer", "description": "Optional user ID to assign the reply to — they receive a notification. Obtain from clickup_member_list."}
                 },
                 "required": ["comment_id", "text"]
@@ -2082,7 +2082,7 @@ pub fn tool_list() -> Value {
                 "type": "object",
                 "properties": {
                     "team_id": {"type": "string", "description": "Workspace (team) ID. Obtain from clickup_workspace_list (field: id). Omit to use the default workspace from config."},
-                    "type": {"type": "string", "description": "Audit event type filter (e.g. 'task_created', 'user_added', 'permission_changed'). Required. See ClickUp docs for the full list."},
+                    "type": {"type": "string", "description": "Audit event type filter. Required. ClickUp's documented categories include 'AUTH', 'HIERARCHY', 'USER', 'CUSTOM_FIELDS', 'AGENT', 'OTHER'. See ClickUp docs for the full enum."},
                     "user_id": {"type": "integer", "description": "Restrict to events performed by this user ID. Obtain from clickup_member_list. Omit for all users."},
                     "start_date": {"type": "integer", "description": "Inclusive lower bound as a Unix timestamp in milliseconds (e.g. 1735689600000 for 2025-01-01). Omit for no lower bound."},
                     "end_date": {"type": "integer", "description": "Inclusive upper bound as a Unix timestamp in milliseconds. Omit for no upper bound."}


### PR DESCRIPTION
## Summary
Audit pass against ClickUp's official OpenAPI spec to surface places where our CLI help text and MCP tool descriptions claimed behaviour ClickUp's API doesn't actually deliver. This PR is documentation-only. No code paths or request bodies change.

The audit grew out of #22 (task descriptions don't render markdown, fixed in #24) and an in-conversation finding that v2 comments don't render markdown either even though our MCP schema claimed they did. We then ran a wider audit across ~165 endpoints. This PR lands the doc-only corrections so they can ship quickly; further audit findings (real bugs that change request bodies or paths) will follow in separate PRs.

### Specific corrections

- **Comments (v2)**. `clickup_comment_create`, `clickup_comment_update`, `clickup_comment_reply` and the CLI `comment create/update/reply --text` help text no longer claim markdown support. ClickUp's v2 comment API only accepts a plain `comment_text` field; markdown syntax is stored verbatim. @mentions are still rendered server side and still work.
- **Docs**. `clickup_doc_create` `parent.type` description had the wrong cheat sheet. Corrected to 4=space, 5=folder, 6=list, 7=everything, 12=workspace. Previous text said 7=task.
- **Webhooks**. `clickup_webhook_delete` previously pointed users at `clickup_webhook_update` with `status='suspended'` as a non-destructive alternative. The API does not accept `suspended`; valid values are `active` / `inactive`. Description updated.
- **Audit log**. `clickup_audit_log_query` `type` parameter description listed invented event names (`task_created`, `user_added`, `permission_changed`). Replaced with ClickUp's actual category enum (AUTH, HIERARCHY, USER, CUSTOM_FIELDS, AGENT, OTHER).
- **Chat**. `clickup_chat_channel_update` `description` field no longer claims markdown support; ClickUp does not document markdown rendering on chat channel description.

## Test plan
- [x] `cargo build` clean
- [x] `cargo clippy -- -D warnings` clean
- [x] `cargo test` 112/112 across 12 suites
- [x] Strings only, no request shape or path changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)