### PR TITLE
fix: align CLI and MCP request bodies with ClickUp's OpenAPI spec

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - `task create --description` and `task update --description` (and the `clickup_task_create` / `clickup_task_update` MCP tools) now render markdown in the ClickUp UI (#22). The CLI was sending the plain-text `description` API field, which doesn't interpret markdown; switched to `markdown_content`, ClickUp's documented markdown-rendering field. Plain-text descriptions still display identically. User-facing flag and MCP schema parameter name (`description`) are unchanged.
+- `list create --content` and `list update --content` (and the `clickup_list_create` / `clickup_list_update` MCP tools) now render markdown in the ClickUp UI. Same root cause as the task-description bug above: the CLI was sending the plain-text `content` field, but ClickUp's docs explicitly say to use `markdown_content` to format a list description. CLI flag and MCP arg name (`content`) are unchanged.
+- `clickup_chat_reaction_add` MCP tool and `chat reaction-add` CLI: the request body field was `emoji`, ClickUp's OpenAPI spec names it `reaction`. The CLI/MCP input arg name remains `emoji`, only the wire field changed. Without this fix the endpoint returned `Reaction required`.
+- `clickup_tag_update` MCP tool sent `tag_fg` / `tag_bg` on the tag-update endpoint. ClickUp's update endpoint uses `fg_color` / `bg_color` (an inconsistency with the create endpoint, which still uses `tag_fg` / `tag_bg`). The CLI was already correct; the MCP tool now matches. Caller-facing arg names unchanged.
+- `task time-in-status` bulk mode comma-joined every task ID into a single `task_ids=` query parameter, which ClickUp treats as one unknown ID. Switched to repeated `task_ids=A&task_ids=B&...` query params per the OpenAPI spec.
+- `doc create --parent-type` sent the type as a string (`"SPACE"` etc.). ClickUp's spec requires an integer enum (4=space, 5=folder, 6=list, 7=everything, 12=workspace). CLI now accepts the string names case-insensitively (plus the raw integers) and translates to the integer enum. Help text expanded to list the new values (EVERYTHING, WORKSPACE).
+- `doc list --creator` sent `creator_id=` as the query param, ClickUp's docs name it `creator`. Filter was silently ignored before; now applies as documented.
 
 ## [0.9.1] - 2026-04-23
 

--- a/src/commands/chat.rs
+++ b/src/commands/chat.rs
@@ -285,7 +285,7 @@ pub async fn execute(command: ChatCommands, cli: &Cli) -> Result<(), CliError> {
             Ok(())
         }
         ChatCommands::ReactionAdd { msg_id, emoji } => {
-            let body = serde_json::json!({ "emoji": emoji });
+            let body = serde_json::json!({ "reaction": emoji });
             let resp = client
                 .post(&format!("{}/messages/{}/reactions", base, msg_id), &body)
                 .await?;

--- a/src/commands/doc.rs
+++ b/src/commands/doc.rs
@@ -25,7 +25,7 @@ pub enum DocCommands {
         /// Visibility: PUBLIC, PRIVATE, or PERSONAL
         #[arg(long)]
         visibility: Option<String>,
-        /// Parent type: SPACE, FOLDER, or LIST
+        /// Parent type: SPACE, FOLDER, LIST, EVERYTHING, or WORKSPACE
         #[arg(long)]
         parent_type: Option<String>,
         /// Parent ID
@@ -100,7 +100,7 @@ pub async fn execute(command: DocCommands, cli: &Cli) -> Result<(), CliError> {
         DocCommands::List { creator, archived } => {
             let mut params = Vec::new();
             if let Some(c) = &creator {
-                params.push(format!("creator_id={}", c));
+                params.push(format!("creator={}", c));
             }
             if archived {
                 params.push("archived=true".to_string());
@@ -135,7 +135,23 @@ pub async fn execute(command: DocCommands, cli: &Cli) -> Result<(), CliError> {
             if parent_type.is_some() || parent_id.is_some() {
                 let mut parent = serde_json::Map::new();
                 if let Some(pt) = parent_type {
-                    parent.insert("type".into(), serde_json::Value::String(pt));
+                    let type_id = match pt.to_uppercase().as_str() {
+                        "SPACE" | "4" => 4,
+                        "FOLDER" | "5" => 5,
+                        "LIST" | "6" => 6,
+                        "EVERYTHING" | "7" => 7,
+                        "WORKSPACE" | "12" => 12,
+                        other => {
+                            return Err(CliError::ClientError {
+                                message: format!(
+                                    "Invalid --parent-type '{}'. Valid values: SPACE, FOLDER, LIST, EVERYTHING, WORKSPACE",
+                                    other
+                                ),
+                                status: 0,
+                            });
+                        }
+                    };
+                    parent.insert("type".into(), serde_json::json!(type_id));
                 }
                 if let Some(pi) = parent_id {
                     parent.insert("id".into(), serde_json::Value::String(pi));

--- a/src/commands/list.rs
+++ b/src/commands/list.rs
@@ -133,7 +133,7 @@ pub async fn execute(command: ListCommands, cli: &Cli) -> Result<(), CliError> {
             };
             let mut body = serde_json::json!({ "name": name });
             if let Some(c) = content {
-                body["content"] = serde_json::Value::String(c);
+                body["markdown_content"] = serde_json::Value::String(c);
             }
             if let Some(p) = priority {
                 body["priority"] = serde_json::json!(p);
@@ -151,7 +151,7 @@ pub async fn execute(command: ListCommands, cli: &Cli) -> Result<(), CliError> {
                 body.insert("name".into(), serde_json::Value::String(n));
             }
             if let Some(c) = content {
-                body.insert("content".into(), serde_json::Value::String(c));
+                body.insert("markdown_content".into(), serde_json::Value::String(c));
             }
             let resp = client
                 .put(

--- a/src/commands/task.rs
+++ b/src/commands/task.rs
@@ -697,13 +697,16 @@ pub async fn execute(command: TaskCommands, cli: &Cli) -> Result<(), CliError> {
                     }
                 }
             } else {
-                // Bulk mode
-                let task_ids = ids.join(",");
+                // Bulk mode. ClickUp's endpoint requires repeated `task_ids=`
+                // query params, not a comma-joined list; a comma-joined value
+                // is treated as a single unknown ID.
+                let query = ids
+                    .iter()
+                    .map(|id| format!("task_ids={}", id))
+                    .collect::<Vec<_>>()
+                    .join("&");
                 let resp = client
-                    .get(&format!(
-                        "/v2/task/bulk_time_in_status/task_ids?task_ids={}",
-                        task_ids
-                    ))
+                    .get(&format!("/v2/task/bulk_time_in_status/task_ids?{}", query))
                     .await?;
                 if cli.output == "json" {
                     println!("{}", serde_json::to_string_pretty(&resp).unwrap());

--- a/src/mcp.rs
+++ b/src/mcp.rs
@@ -3010,7 +3010,7 @@ async fn dispatch_tool(
                 .ok_or("Missing required parameter: name")?;
             let mut body = json!({"name": name});
             if let Some(content) = args.get("content").and_then(|v| v.as_str()) {
-                body["content"] = json!(content);
+                body["markdown_content"] = json!(content);
             }
             if let Some(due_date) = args.get("due_date").and_then(|v| v.as_i64()) {
                 body["due_date"] = json!(due_date);
@@ -3039,7 +3039,7 @@ async fn dispatch_tool(
                 body["name"] = json!(name);
             }
             if let Some(content) = args.get("content").and_then(|v| v.as_str()) {
-                body["content"] = json!(content);
+                body["markdown_content"] = json!(content);
             }
             if let Some(due_date) = args.get("due_date").and_then(|v| v.as_i64()) {
                 body["due_date"] = json!(due_date);
@@ -3928,11 +3928,15 @@ async fn dispatch_tool(
             if let Some(name) = args.get("name").and_then(|v| v.as_str()) {
                 tag["name"] = json!(name);
             }
+            // ClickUp's tag UPDATE endpoint uses `fg_color` / `bg_color`,
+            // unlike CREATE which uses `tag_fg` / `tag_bg`. (Quirk confirmed
+            // against the OpenAPI spec.) Keep the input arg names matching
+            // CREATE for caller ergonomics; translate on the wire.
             if let Some(fg) = args.get("tag_fg").and_then(|v| v.as_str()) {
-                tag["tag_fg"] = json!(fg);
+                tag["fg_color"] = json!(fg);
             }
             if let Some(bg) = args.get("tag_bg").and_then(|v| v.as_str()) {
-                tag["tag_bg"] = json!(bg);
+                tag["bg_color"] = json!(bg);
             }
             let body = json!({"tag": tag});
             client
@@ -4355,7 +4359,7 @@ async fn dispatch_tool(
                 .get("emoji")
                 .and_then(|v| v.as_str())
                 .ok_or("Missing required parameter: emoji")?;
-            let body = json!({"emoji": emoji});
+            let body = json!({"reaction": emoji});
             client
                 .post(
                     &format!(


### PR DESCRIPTION
## Summary
Wave one of the API-spec audit corrections. Six wire-level alignments where ClickUp's published OpenAPI spec is unambiguous and our code disagreed.

User-facing CLI flag names and MCP input argument names are **unchanged**. Only the wire-level body fields and query params change.

### Fixes

1. **list create / update — `markdown_content`**. Same pattern as the task description fix in #24. ClickUp docs explicitly say "Use `markdown_content` instead of `content` to format your List description." `--content` flag stays the same.
2. **chat reaction-add — `emoji` -> `reaction`**. ClickUp's spec names the body field `reaction`. Previously the endpoint returned `Reaction required` on every call.
3. **MCP tag update — `tag_fg`/`tag_bg` -> `fg_color`/`bg_color`**. Update uses different field names than create (documented quirk). CLI was already correct; only the MCP path was wrong.
4. **task time-in-status bulk — repeated query params**. Was comma-joining IDs into a single `task_ids=` value, which ClickUp treats as one unknown ID. Now sends `task_ids=A&task_ids=B&...` per the spec.
5. **doc create `--parent-type` — string -> int enum**. ClickUp wants an integer enum (4=space, 5=folder, 6=list, 7=everything, 12=workspace). CLI now accepts the case-insensitive string names plus raw integers and translates on the wire.
6. **doc list `--creator` — query param renamed**. Was `creator_id=`, spec says `creator`. Filter was silently ignored before.

### Test plan
- [x] `cargo build` clean
- [x] `cargo clippy -- -D warnings` clean
- [x] `cargo test` 112/112 across 12 suites
- [x] Manual smoke tests against the live ClickUp API (results below)

### Smoke test results

| Fix | Result |
|---|---|
| 1. list markdown_content (create + update) | Confirmed rendering. Sent `**bold**`/`*italic*`/`` `code` `` and bullets; ClickUp returned the stored content with all markdown markup stripped (plain rendered text), same proof pattern used for #22. |
| 2. chat reaction-add | Not testable in this workspace (no accessible chat channels). Relying on the OpenAPI spec, which unambiguously names the field `reaction`. |
| 3. MCP tag update | MCP returns success on the new code path, but the ClickUp API silently does not persist colour changes regardless of body shape (also true of the CLI path, which was already correct per the spec). Looks like an upstream API limitation rather than a code defect. This PR aligns MCP with the CLI and with the schema; if colour updates start working in a future ClickUp release, this code will already be correct. |
| 4. bulk time-in-status with 2 IDs | Confirmed. Response is a dict keyed by both task IDs with each task's status. Pre-fix the comma-joined value would have returned a single unknown ID. |
| 5. doc create `--parent-type SPACE` | Confirmed. Doc created successfully with the integer enum translation. |
| 6. doc list `--creator` filter | Confirmed. Filtered response differs from unfiltered, proving the query param is now being applied server-side. |

Additional findings from the wider audit (group create field shape, audit-log body shape, ACL body shape, time-entry tag shape, goal `multiple_owners`, view-create full body, MCP `custom_task_ids` parity across task-scoped tools, chat list-envelope unwrap, etc.) will follow in subsequent PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
