### PR TITLE
fix(chat): read v3 data envelope in CLI list dispatches (#39)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- `chat channel-list`, `chat message-list`, and `chat reply-list` CLI commands now read the v3 `data` envelope first and fall back to the older `channels`/`messages`/`replies` keys for compatibility (#39). Before this fix the commands consistently returned empty results because the v3 endpoints return their list under `data` — the matching MCP tools were already fixed in 0.10.0 but the CLI parity was missed.
+
 ## [0.10.0] - 2026-05-18
 
 ### Changed

--- a/src/commands/chat.rs
+++ b/src/commands/chat.rs
@@ -165,8 +165,10 @@ pub async fn execute(command: ChatCommands, cli: &Cli) -> Result<(), CliError> {
                 ""
             };
             let resp = client.get(&format!("{}/channels{}", base, query)).await?;
+            // v3 envelope wraps the list in "data"; older shape used "channels".
             let mut channels = resp
-                .get("channels")
+                .get("data")
+                .or_else(|| resp.get("channels"))
                 .and_then(|v| v.as_array())
                 .cloned()
                 .unwrap_or_default();
@@ -238,14 +240,14 @@ pub async fn execute(command: ChatCommands, cli: &Cli) -> Result<(), CliError> {
             let resp = client
                 .get(&format!("{}/channels/{}/messages", base, channel))
                 .await?;
+            // v3 envelope wraps the list in "data"; older shape used "messages",
+            // and some endpoints return a bare array.
             let mut messages = resp
-                .get("messages")
+                .get("data")
+                .or_else(|| resp.get("messages"))
                 .and_then(|v| v.as_array())
                 .cloned()
-                .unwrap_or_else(|| {
-                    // Response may be an array directly
-                    resp.as_array().cloned().unwrap_or_default()
-                });
+                .unwrap_or_else(|| resp.as_array().cloned().unwrap_or_default());
             if let Some(limit) = cli.limit {
                 messages.truncate(limit);
             }
@@ -320,8 +322,11 @@ pub async fn execute(command: ChatCommands, cli: &Cli) -> Result<(), CliError> {
             let resp = client
                 .get(&format!("{}/messages/{}/replies", base, msg_id))
                 .await?;
+            // v3 envelope wraps the list in "data"; older shape used "replies",
+            // and some endpoints return a bare array.
             let mut replies = resp
-                .get("replies")
+                .get("data")
+                .or_else(|| resp.get("replies"))
                 .and_then(|v| v.as_array())
                 .cloned()
                 .unwrap_or_else(|| resp.as_array().cloned().unwrap_or_default());


### PR DESCRIPTION
## Summary

Fixes #39. The MCP tools learned to read the v3 `data` envelope in 0.10.0 (see CHANGELOG entry for `clickup_chat_message_list`, `clickup_chat_channel_list`, `clickup_chat_reply_list`), but the matching CLI dispatches were left looking under the old `channels` / `messages` / `replies` keys. As a result `clickup chat channel-list`, `chat message-list`, and `chat reply-list` consistently returned empty tables even though the underlying v3 endpoints return the expected data — the reporter confirmed this by hitting the raw HTTP endpoint with the same token.

This change mirrors the MCP fix in three CLI dispatches in `src/commands/chat.rs`:

- `channel-list` (chat.rs:167) — try `data` first, fall back to `channels`.
- `message-list` (chat.rs:237) — try `data` first, fall back to `messages`, then a bare array.
- `reply-list` (chat.rs:319) — try `data` first, fall back to `replies`, then a bare array.

No behaviour change for any caller that was already working; this only un-breaks the empty-result case.

## Test plan

- [x] `cargo build` — clean
- [x] `cargo test` — full suite passes (112/112)
- [x] Live smoke test: `clickup chat channel-list` against a real workspace — returns the populated channel list (previously empty)
- [x] Live smoke test: `clickup chat message-list --channel <id>` — returns real messages (previously empty)
- [x] Live smoke test: `clickup chat reply-list <threaded-msg-id>` — returns the thread's replies (previously empty)

🤖 Generated with [Claude Code](https://claude.com/claude-code)