### PR TITLE
docs: add Star History section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -453,6 +453,16 @@ Other community tools in the ClickUp ecosystem — picking the right one depends
 
 Rust binary, zero runtime dependency, ~130 REST endpoints + 143 MCP tools (100% API coverage), statically linked musl build for Alpine / distroless containers, and token-efficient output tuned for LLM agents. Use this when you want one binary that covers both the CLI and MCP roles without a Node/Python toolchain.
 
+## Star History
+
+<a href="https://www.star-history.com/?repos=nicholasbester%2Fclickup-cli&type=date&legend=top-left">
+ <picture>
+   <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/chart?repos=nicholasbester/clickup-cli&type=date&theme=dark&legend=top-left" />
+   <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/chart?repos=nicholasbester/clickup-cli&type=date&legend=top-left" />
+   <img alt="Star History Chart" src="https://api.star-history.com/chart?repos=nicholasbester/clickup-cli&type=date&legend=top-left" />
+ </picture>
+</a>
+
 ## License
 
 [Apache-2.0](LICENSE)


### PR DESCRIPTION
## Summary

Adds the [star-history.com](https://www.star-history.com/) chart embed to the README, with `prefers-color-scheme` handling so the chart renders correctly in both light and dark GitHub themes.

## Placement

Just above the `## License` section, after "Where this project fits". Keeps the project positioning as the closing pitch and tucks the star chart as the final pre-license visual.

## Test plan

- [x] Markdown renders locally (preview); both `<source>` URLs return 200 from the star-history API.
- [ ] Visual check on the rendered GitHub README page once merged — light + dark theme.

🤖 Generated with [Claude Code](https://claude.com/claude-code)