### PR TITLE
ci(npm): migrate npm publish to OIDC Trusted Publishing

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,6 +8,11 @@ on:
 permissions:
   contents: write
   packages: write
+  # Required so the npm CLI can request an OIDC token from GitHub for
+  # the npm Trusted Publishing exchange. Replaces the long-lived
+  # NPM_TOKEN secret. See:
+  # https://docs.npmjs.com/trusted-publishers
+  id-token: write
 
 jobs:
   build:
@@ -158,10 +163,17 @@ jobs:
           node-version: 20
           registry-url: https://registry.npmjs.org
 
+      # npm Trusted Publishing: the npm CLI (>= 11.5.1) auto-exchanges the
+      # workflow's OIDC token (granted via `id-token: write` above) for a
+      # short-lived publish credential. No NPM_TOKEN env var needed.
+      # Configured on npmjs.com -> Package settings -> Publishing access ->
+      # Trusted publisher = nicholasbester/clickup-cli, workflow build.yml.
+      - name: Upgrade npm to a Trusted-Publishing-capable version
+        if: ${{ !contains(github.ref_name, '-') }}
+        run: npm install -g npm@latest
+
       - name: Publish to npm
         if: ${{ !contains(github.ref_name, '-') }}
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: |
           VERSION="${GITHUB_REF_NAME#v}"
           cd npm
@@ -169,7 +181,9 @@ jobs:
           if npm view "@nick.bester/clickup-cli@${VERSION}" version >/dev/null 2>&1; then
             echo "::notice::npm: version ${VERSION} already exists, skipping"
           else
-            npm publish --access public
+            # --provenance attaches a build attestation; required by npm's
+            # trusted-publishing flow.
+            npm publish --access public --provenance
           fi
 
       - name: Setup Node.js (GitHub Packages)


### PR DESCRIPTION
## Summary

Replaces the long-lived \`NPM_TOKEN\` secret with OIDC-based Trusted Publishing per [npm's recommendation](https://docs.npmjs.com/trusted-publishers).

**Context:** npm rotated all granular access tokens with write access that bypass 2FA following the "Mini Shai-Hulud" supply chain attacks. The previous \`NPM_TOKEN\` secret was invalidated, which caused v0.12.0's npm publish step to fail with \`404 PUT @nick.bester/clickup-cli\`. Trusted Publishing avoids the long-lived token problem entirely.

## ⚠️ Maintainer setup required BEFORE merging

This PR is unmergeable until npmjs.com is configured.

1. Sign in to npmjs.com as the package owner.
2. Go to \`@nick.bester/clickup-cli\` package settings → **Publishing access** (or "Trusted Publishers" section).
3. Add a new trusted publisher with:
   - **Publisher**: GitHub Actions
   - **Repository**: \`nicholasbester/clickup-cli\`
   - **Workflow file name**: \`build.yml\`
   - **Environment** (optional): leave blank
4. Save.

Once configured, this PR is safe to merge.

## Workflow changes (\`.github/workflows/build.yml\`)

- **Job-level permissions** gain \`id-token: write\` so the npm CLI can request the OIDC token from GitHub.
- **New step**: \`Upgrade npm to a Trusted-Publishing-capable version\` runs \`npm install -g npm@latest\`. Node 20 LTS ships npm 10.x; Trusted Publishing requires npm ≥ 11.5.1.
- **\`Publish to npm\` step**:
  - Drops the \`env: NODE_AUTH_TOKEN: \${{ secrets.NPM_TOKEN }}\` block entirely.
  - Adds \`--provenance\` to \`npm publish\` (required by the trusted-publishing flow's build-attestation).
- **GitHub Packages publish step is untouched** — it uses \`GITHUB_TOKEN\` via \`secrets.GITHUB_TOKEN\`, not the npm registry's auth path.

## Why Trusted Publishing?

- Eliminates the long-lived-token rotation problem entirely.
- OIDC token is short-lived and scoped to the specific workflow run, so a compromised CI environment can't be replayed.
- npm enforces that the publishing workflow matches the configured trusted publisher; an attacker who hijacks an unrelated repo cannot publish to your scope.
- Aligns with npm's post-Shai-Hulud security recommendation.

## After merge

- The next tag-triggered release will exchange the workflow's OIDC token for a short-lived npm publish credential automatically — no \`NPM_TOKEN\` env var needed.
- The \`NPM_TOKEN\` repo secret can then be deleted from \`Settings → Secrets and variables → Actions\`.
- Verify \`npm view @nick.bester/clickup-cli@<version> dist.attestations\` shows the provenance attestation.

## Test plan

- [ ] Maintainer configures trusted-publisher entry on npmjs.com before merging.
- [ ] After merge, cut a patch release (or re-run the v0.12.0 release workflow) and confirm npm publish succeeds.
- [ ] Confirm provenance attestation is attached to the published version.

🤖 Generated with [Claude Code](https://claude.com/claude-code)