### PR TITLE
feat(config): walk up from CWD to find nearest .clickup.toml

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -39,17 +39,24 @@ impl Config {
         Ok(config_dir.join("clickup-cli").join("config.toml"))
     }
 
-    /// Load config: project-level .clickup.toml first, then global config
+    /// Walk from `start` up to filesystem root, returning the nearest `.clickup.toml`.
+    pub fn find_project_config(start: &std::path::Path) -> Option<PathBuf> {
+        start.ancestors().find_map(|dir| {
+            let candidate = dir.join(".clickup.toml");
+            candidate.is_file().then_some(candidate)
+        })
+    }
+
+    /// Load config: nearest .clickup.toml walking up from CWD, then global config
     pub fn load() -> Result<Self, CliError> {
-        // 1. Project-level config (.clickup.toml in current directory)
-        let project_path = PathBuf::from(".clickup.toml");
-        if project_path.exists() {
-            let project_config = Self::load_from(&project_path)?;
-            if !project_config.auth.token.is_empty() {
-                return Ok(project_config);
+        if let Ok(cwd) = std::env::current_dir() {
+            if let Some(project_path) = Self::find_project_config(&cwd) {
+                let project_config = Self::load_from(&project_path)?;
+                if !project_config.auth.token.is_empty() {
+                    return Ok(project_config);
+                }
             }
         }
-        // 2. Global config
         let path = Self::config_path()?;
         Self::load_from(&path)
     }

--- a/tests/test_config.rs
+++ b/tests/test_config.rs
@@ -46,6 +46,41 @@ fn test_config_minimal_toml() {
 }
 
 #[test]
+fn test_find_project_config_walks_up_to_root() {
+    let dir = TempDir::new().unwrap();
+    let root = dir.path().canonicalize().unwrap();
+    std::fs::write(root.join(".clickup.toml"), "[auth]\ntoken = \"pk_root\"\n").unwrap();
+    let nested = root.join("a").join("b").join("c");
+    std::fs::create_dir_all(&nested).unwrap();
+
+    let found = Config::find_project_config(&nested).expect("should find ancestor config");
+    assert_eq!(found, root.join(".clickup.toml"));
+}
+
+#[test]
+fn test_find_project_config_prefers_nearest() {
+    let dir = TempDir::new().unwrap();
+    let root = dir.path().canonicalize().unwrap();
+    std::fs::write(root.join(".clickup.toml"), "[auth]\ntoken = \"pk_root\"\n").unwrap();
+    let sub = root.join("sub");
+    std::fs::create_dir_all(&sub).unwrap();
+    std::fs::write(sub.join(".clickup.toml"), "[auth]\ntoken = \"pk_sub\"\n").unwrap();
+    let nested = sub.join("deeper");
+    std::fs::create_dir_all(&nested).unwrap();
+
+    let found = Config::find_project_config(&nested).expect("should find nearest config");
+    assert_eq!(found, sub.join(".clickup.toml"));
+}
+
+#[test]
+fn test_find_project_config_none_when_absent() {
+    let dir = TempDir::new().unwrap();
+    let nested = dir.path().join("a").join("b");
+    std::fs::create_dir_all(&nested).unwrap();
+    assert!(Config::find_project_config(&nested).is_none());
+}
+
+#[test]
 fn test_config_save_creates_parent_dirs() {
     let dir = TempDir::new().unwrap();
     let path = dir.path().join("deep").join("nested").join("config.toml");


### PR DESCRIPTION
## Summary
- `Config::load()` now walks `current_dir().ancestors()` for the nearest `.clickup.toml`, matching how git locates `.git`.
- Previously the CLI only checked `.clickup.toml` in the current directory, so running from any subdirectory of a project silently fell back to the global config (often surfacing as a `401` from a wrong-workspace token).
- Setup and `agent-config init` still write to CWD — only the read path changed.

## Test plan
- [x] `cargo test --test test_config` — 7 pass, including 3 new tests (walks to root, prefers nearest, returns None when absent).
- [x] Verified end-to-end from `src/commands/` (3 levels deep) — authenticates against the project token.
- [x] Verified from `docs/_layouts/` with `HOME=/nonexistent` — still authenticates, proving the walk resolves it (not a global fallback).

🤖 Generated with [Claude Code](https://claude.com/claude-code)