### PR TITLE
feat(mcp): include custom_id in task tool responses (#82)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- MCP task tools now include the task's `custom_id` in their compact responses (#82). Applies to `clickup_task_get`, `clickup_task_search`, `clickup_task_list`, `clickup_task_create`, `clickup_task_update`, and `clickup_view_tasks`. The field is only present when the task actually has a custom ID, so workspaces that don't use custom task IDs see byte-identical output (and pay no extra tokens). The ClickUp API already returns `custom_id` on task objects — no request changes; the `custom_task_ids=true` query parameter remains input-side only (addressing a task *by* its custom ID), which the MCP server already supported.
+
 ## [0.14.0] - 2026-06-24
 
 ### Added

--- a/docs/superpowers/plans/2026-07-22-mcp-custom-id.md
+++ b/docs/superpowers/plans/2026-07-22-mcp-custom-id.md
@@ -1,0 +1,368 @@
+# MCP `custom_id` Exposure Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Surface `custom_id` in the compact responses of every task-returning MCP tool, omitting the key when the task has no custom ID (GitHub issue #82).
+
+**Architecture:** All MCP tool responses are projected through `output::compact_items(items, fields)`, which emits every listed field with a `"-"` placeholder when missing. We teach it an optional-field convention — a trailing `?` on a field name (e.g. `"custom_id?"`) means "emit under the clean name only when present and non-null" — then add `"custom_id?"` to the six task-returning tools' field lists. No API request changes: ClickUp already returns `custom_id` on task objects.
+
+**Tech Stack:** Rust, serde_json, wiremock + assert_cmd for integration tests.
+
+**Spec:** `docs/superpowers/specs/2026-07-22-mcp-custom-id-design.md`
+
+## Global Constraints
+
+- Backward compatible: tasks without a custom ID must produce byte-identical output to today.
+- Affected tools (6): `clickup_task_get`, `clickup_task_search`, `clickup_task_list`, `clickup_task_create`, `clickup_task_update`, `clickup_view_tasks`. (`clickup_task_move` was listed in the spec but returns only a `{"message": ...}` confirmation, not a task object — out of scope; Task 2 amends the spec.)
+- Non-optional fields in `compact_items` keep exact current behaviour (always present, `"-"` when missing/null).
+- Work on branch `feat/mcp-custom-id-issue-82`.
+
+---
+
+### Task 1: Optional-field marker in `compact_items`
+
+**Files:**
+- Modify: `src/output.rs:92-107` (the `compact_items` function)
+- Test: `tests/test_output.rs` (append)
+
+**Interfaces:**
+- Consumes: existing `flatten_value(Option<&serde_json::Value>) -> String` in `src/output.rs`.
+- Produces: `compact_items(items: &[serde_json::Value], fields: &[&str]) -> serde_json::Value` now interprets a field spelled with a trailing `?` (e.g. `"custom_id?"`) as optional: output key is the name without the `?`, and the key is omitted entirely when the source value is missing or JSON null. Task 2 relies on exactly this.
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `tests/test_output.rs` (note: this file currently only imports `flatten_value` and `OutputConfig`; add `compact_items` to the existing `use clickup_cli::output::{...}` line):
+
+```rust
+#[test]
+fn compact_items_includes_optional_field_when_present() {
+    let items = vec![json!({"id": "abc123", "name": "demo", "custom_id": "PROJ-42"})];
+    let result = compact_items(&items, &["id", "name", "custom_id?"]);
+    assert_eq!(result[0]["id"], json!("abc123"));
+    assert_eq!(result[0]["custom_id"], json!("PROJ-42"));
+    // The marker itself must never leak into the output.
+    assert!(result[0].get("custom_id?").is_none());
+}
+
+#[test]
+fn compact_items_omits_optional_field_when_null() {
+    let items = vec![json!({"id": "abc123", "name": "demo", "custom_id": null})];
+    let result = compact_items(&items, &["id", "name", "custom_id?"]);
+    assert!(result[0].get("custom_id").is_none());
+    assert_eq!(result[0]["name"], json!("demo"));
+}
+
+#[test]
+fn compact_items_omits_optional_field_when_missing() {
+    let items = vec![json!({"id": "abc123", "name": "demo"})];
+    let result = compact_items(&items, &["id", "name", "custom_id?"]);
+    assert!(result[0].get("custom_id").is_none());
+}
+
+#[test]
+fn compact_items_required_field_still_placeholder_when_missing() {
+    let items = vec![json!({"id": "abc123"})];
+    let result = compact_items(&items, &["id", "name"]);
+    assert_eq!(result[0]["name"], json!("-"));
+}
+```
+
+- [ ] **Step 2: Run tests to verify the new ones fail**
+
+Run: `cargo test --test test_output`
+Expected: the three `optional_field` tests FAIL (current code emits key `"custom_id?"` with value `"-"` or the flattened value); `compact_items_required_field_still_placeholder_when_missing` PASSES (documents existing behaviour).
+
+- [ ] **Step 3: Implement the marker in `compact_items`**
+
+Replace the function in `src/output.rs` (keep `flatten_value` untouched):
+
+```rust
+/// Flatten a list of items to only include the specified fields with flattened values.
+/// Returns a JSON array. Used by MCP server for token-efficient responses.
+///
+/// A field name with a trailing `?` (e.g. `"custom_id?"`) is optional: it is
+/// emitted under the name without the marker, and only when the source value
+/// is present and non-null. All other fields are always emitted, with `"-"`
+/// as the placeholder for missing/null values.
+pub fn compact_items(items: &[serde_json::Value], fields: &[&str]) -> serde_json::Value {
+    let compacted: Vec<serde_json::Value> = items
+        .iter()
+        .map(|item| {
+            let mut obj = serde_json::Map::new();
+            for &field in fields {
+                if let Some(key) = field.strip_suffix('?') {
+                    match item.get(key) {
+                        None | Some(serde_json::Value::Null) => {}
+                        Some(v) => {
+                            let val = flatten_value(Some(v));
+                            obj.insert(key.to_string(), serde_json::Value::String(val));
+                        }
+                    }
+                } else {
+                    let val = flatten_value(item.get(field));
+                    obj.insert(field.to_string(), serde_json::Value::String(val));
+                }
+            }
+            serde_json::Value::Object(obj)
+        })
+        .collect();
+    serde_json::Value::Array(compacted)
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cargo test --test test_output`
+Expected: all tests PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/output.rs tests/test_output.rs
+git commit -m "feat(output): optional-field '?' marker in compact_items (#82)"
+```
+
+---
+
+### Task 2: Add `custom_id?` to the six task-returning MCP tools
+
+**Files:**
+- Modify: `src/mcp.rs` — six field lists (approx. lines 2461, 2498, 2548, 2585, 2607, 2901) and four tool descriptions (approx. lines 237, 262, 340, 592)
+- Modify: `docs/superpowers/specs/2026-07-22-mcp-custom-id-design.md` (scope amendment)
+- Test: `tests/test_mcp_custom_id.rs` (create)
+
+**Interfaces:**
+- Consumes: `compact_items` optional-field marker from Task 1 (`"custom_id?"` → key `custom_id` emitted only when set).
+- Produces: MCP tool responses for the six tools carry `"custom_id": "<value>"` when the task has one; unchanged otherwise.
+
+- [ ] **Step 1: Write the failing integration test**
+
+Create `tests/test_mcp_custom_id.rs`. The MCP server handles `tools/call` statelessly line-by-line over stdio and exits cleanly when stdin closes, so a test can spawn the binary, write one JSON-RPC line, and assert on stdout. Follow the wiremock + env pattern of `tests/test_task_markdown.rs`:
+
+```rust
+use assert_cmd::Command;
+use std::path::Path;
+use tempfile::TempDir;
+use wiremock::matchers::{method, path as path_matcher};
+use wiremock::{Mock, MockServer, ResponseTemplate};
+
+fn mcp_serve(dir: &Path, server: &MockServer) -> Command {
+    let mut cmd = Command::cargo_bin("clickup-cli").unwrap();
+    cmd.current_dir(dir)
+        .args(["mcp", "serve"])
+        .env("CLICKUP_API_URL", server.uri())
+        .env("CLICKUP_TOKEN", "pk_test")
+        .env("CLICKUP_WORKSPACE", "99")
+        .env_remove("CLICKUP_GIT_DETECT")
+        .env_remove("CLICKUP_TASK_ID");
+    cmd
+}
+
+fn rpc_call(tool: &str, arguments: serde_json::Value) -> String {
+    serde_json::json!({
+        "jsonrpc": "2.0",
+        "id": 1,
+        "method": "tools/call",
+        "params": {"name": tool, "arguments": arguments}
+    })
+    .to_string()
+        + "\n"
+}
+
+#[tokio::test]
+async fn task_get_includes_custom_id_when_set() {
+    let dir = TempDir::new().unwrap();
+    let server = MockServer::start().await;
+
+    Mock::given(method("GET"))
+        .and(path_matcher("/v2/task/abc123"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "id": "abc123",
+            "name": "demo",
+            "custom_id": "PROJ-42",
+            "status": {"status": "open"},
+        })))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    mcp_serve(dir.path(), &server)
+        .write_stdin(rpc_call(
+            "clickup_task_get",
+            serde_json::json!({"task_id": "abc123"}),
+        ))
+        .assert()
+        .success()
+        .stdout(predicates::str::contains("custom_id"))
+        .stdout(predicates::str::contains("PROJ-42"));
+}
+
+#[tokio::test]
+async fn task_get_omits_custom_id_when_null() {
+    let dir = TempDir::new().unwrap();
+    let server = MockServer::start().await;
+
+    Mock::given(method("GET"))
+        .and(path_matcher("/v2/task/abc123"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "id": "abc123",
+            "name": "demo",
+            "custom_id": null,
+        })))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    mcp_serve(dir.path(), &server)
+        .write_stdin(rpc_call(
+            "clickup_task_get",
+            serde_json::json!({"task_id": "abc123"}),
+        ))
+        .assert()
+        .success()
+        .stdout(predicates::str::contains("custom_id").not());
+}
+
+#[tokio::test]
+async fn task_search_includes_custom_id_when_set() {
+    let dir = TempDir::new().unwrap();
+    let server = MockServer::start().await;
+
+    Mock::given(method("GET"))
+        .and(path_matcher("/v2/team/99/task"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "tasks": [
+                {"id": "abc123", "name": "with custom", "custom_id": "PROJ-42"},
+                {"id": "def456", "name": "without custom", "custom_id": null},
+            ]
+        })))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    mcp_serve(dir.path(), &server)
+        .write_stdin(rpc_call("clickup_task_search", serde_json::json!({})))
+        .assert()
+        .success()
+        .stdout(predicates::str::contains("PROJ-42"));
+}
+```
+
+Add `use predicates::prelude::*;` if `.not()` fails to resolve — `predicates::str::contains(...).not()` requires the `PredicateBooleanExt` trait from the prelude.
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `cargo test --test test_mcp_custom_id`
+Expected: `task_get_includes_custom_id_when_set` and `task_search_includes_custom_id_when_set` FAIL (no `custom_id`/`PROJ-42` in stdout); `task_get_omits_custom_id_when_null` PASSES (nothing emits custom_id yet).
+
+- [ ] **Step 3: Add `"custom_id?"` to the six field lists in `src/mcp.rs`**
+
+In each of the following handlers, insert `"custom_id?"` immediately after `"id"` in the compact field list:
+
+1. `clickup_task_list` (~line 2461, inside `pagination::page_dispatch`):
+```rust
+&["id", "custom_id?", "name", "status", "priority", "assignees", "due_date"],
+```
+2. `clickup_task_get` (~line 2498, the `let mut fields = vec![...]`):
+```rust
+let mut fields = vec![
+    "id",
+    "custom_id?",
+    "name",
+    "status",
+    "priority",
+    "assignees",
+    "due_date",
+    "description",
+];
+```
+3. `clickup_task_create` (~line 2548, inside `compact_items`):
+```rust
+&["id", "custom_id?", "name", "status", "priority", "assignees", "due_date"],
+```
+4. `clickup_task_update` (~line 2585, inside `compact_items`):
+```rust
+&["id", "custom_id?", "name", "status", "priority", "assignees", "due_date"],
+```
+5. `clickup_task_search` (~line 2607, inside `pagination::page_dispatch`):
+```rust
+&["id", "custom_id?", "name", "status", "priority", "assignees", "due_date"],
+```
+6. `clickup_view_tasks` (~line 2901, inside `pagination::page_dispatch`):
+```rust
+&["id", "custom_id?", "name", "status", "priority", "assignees", "due_date"],
+```
+
+- [ ] **Step 4: Update the four tool descriptions that describe returned task shapes**
+
+All in `src/mcp.rs`. Only the quoted fragments change:
+
+1. `clickup_task_list` (~line 237): change `Returns the first page of task objects in compact form (id, name, status, assignees, due_date).` to `Returns the first page of task objects in compact form (id, name, status, assignees, due_date; custom_id when the task has one).`
+2. `clickup_task_get` (~line 262): after `Returns the task object.` add ` Includes the task's custom_id when one is set.`
+3. `clickup_task_search` (~line 340): change `Returns a compact array of task objects.` to `Returns a compact array of task objects (custom_id included when set).`
+4. `clickup_view_tasks` (~line 592): change `Returns a compact array of task objects.` to `Returns a compact array of task objects (custom_id included when set).`
+
+- [ ] **Step 5: Run the tests to verify they pass**
+
+Run: `cargo test --test test_mcp_custom_id`
+Expected: all 3 tests PASS.
+
+- [ ] **Step 6: Amend the spec's scope note**
+
+In `docs/superpowers/specs/2026-07-22-mcp-custom-id-design.md`, change the affected-tools line to six tools and note why `clickup_task_move` dropped out:
+
+Replace:
+```
+**Affected tools (7):** `clickup_task_get`, `clickup_task_search`,
+`clickup_task_list`, `clickup_task_create`, `clickup_task_update`,
+`clickup_view_tasks`, `clickup_task_move`.
+```
+With:
+```
+**Affected tools (6):** `clickup_task_get`, `clickup_task_search`,
+`clickup_task_list`, `clickup_task_create`, `clickup_task_update`,
+`clickup_view_tasks`. (`clickup_task_move` was originally in scope but
+returns only a `{"message": ...}` confirmation, not a task object, so
+there is nothing to add a field to.)
+```
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/mcp.rs tests/test_mcp_custom_id.rs docs/superpowers/specs/2026-07-22-mcp-custom-id-design.md
+git commit -m "feat(mcp): include custom_id in task tool responses when set (#82)"
+```
+
+---
+
+### Task 3: Changelog + full verification
+
+**Files:**
+- Modify: `CHANGELOG.md` (the `## [Unreleased]` section)
+
+**Interfaces:**
+- Consumes: the finished behaviour from Tasks 1–2.
+- Produces: release notes; a fully green test suite.
+
+- [ ] **Step 1: Add the changelog entry**
+
+Under `## [Unreleased]` in `CHANGELOG.md`, add:
+
+```markdown
+### Added
+- MCP task tools now include the task's `custom_id` in their compact responses (#82). Applies to `clickup_task_get`, `clickup_task_search`, `clickup_task_list`, `clickup_task_create`, `clickup_task_update`, and `clickup_view_tasks`. The field is only present when the task actually has a custom ID, so workspaces that don't use custom task IDs see byte-identical output (and pay no extra tokens). The ClickUp API already returns `custom_id` on task objects — no request changes; the `custom_task_ids=true` query parameter remains input-side only (addressing a task *by* its custom ID), which the MCP server already supported.
+```
+
+(If a later task has already created an `### Added` heading under `[Unreleased]`, append the bullet to it instead of adding a second heading.)
+
+- [ ] **Step 2: Run the full test suite and lints**
+
+Run: `cargo test && cargo clippy --all-targets -- -D warnings && cargo fmt --check`
+Expected: all tests PASS, no clippy warnings, no formatting diffs. If `cargo fmt --check` fails, run `cargo fmt` and include the reformat in the commit.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add CHANGELOG.md
+git commit -m "docs: changelog entry for MCP custom_id exposure (#82)"
+```

--- a/docs/superpowers/specs/2026-07-22-mcp-custom-id-design.md
+++ b/docs/superpowers/specs/2026-07-22-mcp-custom-id-design.md
@@ -22,9 +22,11 @@ Include `custom_id` in the compact output of every MCP tool that returns task
 objects, omitting the key entirely when the task has no custom ID so
 workspaces that don't use the feature pay zero token overhead.
 
-**Affected tools (7):** `clickup_task_get`, `clickup_task_search`,
+**Affected tools (6):** `clickup_task_get`, `clickup_task_search`,
 `clickup_task_list`, `clickup_task_create`, `clickup_task_update`,
-`clickup_view_tasks`, `clickup_task_move`.
+`clickup_view_tasks`. (`clickup_task_move` was originally in scope but
+returns only a `{"message": ...}` confirmation, not a task object, so
+there is nothing to add a field to.)
 
 ## Approach
 

--- a/docs/superpowers/specs/2026-07-22-mcp-custom-id-design.md
+++ b/docs/superpowers/specs/2026-07-22-mcp-custom-id-design.md
@@ -1,0 +1,67 @@
+# MCP: surface `custom_id` in task responses — design
+
+**Date:** 2026-07-22
+**Issue:** [#82 — MCP: clickup_task_get / clickup_task_search omit custom_id metadata](https://github.com/nicholasbester/clickup-cli/issues/82)
+
+## Problem
+
+The ClickUp API returns `custom_id` on every task object (null when the
+workspace doesn't use custom task IDs). The MCP server drops it: every task
+tool projects the API response through a fixed field whitelist via
+`output::compact_items`, and `custom_id` is not in any of those whitelists.
+MCP consumers therefore cannot display or prefer custom IDs, breaking parity
+with the CLI, where `--fields custom_id` or `--output json` exposes the value.
+
+No request-side change is needed. The `custom_task_ids=true&team_id=<ws>`
+query parameter only affects *addressing* a task by its custom ID on input,
+which `resolve_task` in `src/mcp.rs` already handles.
+
+## Decision
+
+Include `custom_id` in the compact output of every MCP tool that returns task
+objects, omitting the key entirely when the task has no custom ID so
+workspaces that don't use the feature pay zero token overhead.
+
+**Affected tools (7):** `clickup_task_get`, `clickup_task_search`,
+`clickup_task_list`, `clickup_task_create`, `clickup_task_update`,
+`clickup_view_tasks`, `clickup_task_move`.
+
+## Approach
+
+Teach `compact_items` an optional-field convention: a field spelled with a
+trailing `?` (e.g. `"custom_id?"`) is stripped to its clean name and included
+in the output object only when the source value is present and non-null.
+Fields without the marker keep today's behaviour exactly (always present,
+`"-"` placeholder when missing).
+
+Alternatives rejected:
+
+- **Separate `compact_items_opt` / extra `optional_fields` parameter** —
+  requires threading a new parameter through all four pagination dispatch
+  functions (`page_dispatch`, `cursor_dispatch`, `start_id_dispatch`,
+  `body_dispatch`) and every call site. High churn for one field.
+- **Post-processing re-injection** — raw items are not accessible after
+  paginated dispatch; fragile.
+- **Always include with `"-"` placeholder** — uniform schema but adds ~6
+  tokens per task row for every workspace, against the server's
+  token-efficiency goal.
+
+## Changes
+
+1. `src/output.rs` — `compact_items`: detect trailing `?` on a field name;
+   strip it for the output key; skip insertion when the value is missing or
+   JSON null. Document the convention in the doc comment.
+2. `src/mcp.rs` — append `"custom_id?"` to the compact field lists of the 7
+   tools above. Update tool descriptions that enumerate returned fields
+   (e.g. `clickup_task_list`) to note `custom_id` is included when set.
+3. Tests:
+   - `compact_items` unit tests: optional field present → emitted under the
+     clean key; null/missing → key omitted; non-optional fields unchanged.
+   - MCP-level assertions that the task tools' field projections include
+     `custom_id` when the API payload carries one and omit it when null.
+
+## Backward compatibility
+
+Purely additive. Tasks without a custom ID produce byte-identical output to
+today. Existing keys, their order semantics, and placeholder behaviour are
+unchanged.

--- a/docs/superpowers/specs/2026-07-22-mcp-custom-id-design.md
+++ b/docs/superpowers/specs/2026-07-22-mcp-custom-id-design.md
@@ -26,7 +26,9 @@ workspaces that don't use the feature pay zero token overhead.
 `clickup_task_list`, `clickup_task_create`, `clickup_task_update`,
 `clickup_view_tasks`. (`clickup_task_move` was originally in scope but
 returns only a `{"message": ...}` confirmation, not a task object, so
-there is nothing to add a field to.)
+there is nothing to add a field to.) (`clickup_template_apply_task` also
+returns a task object but keeps its deliberately minimal id/name
+projection — possible follow-up.)
 
 ## Approach
 
@@ -53,7 +55,7 @@ Alternatives rejected:
 1. `src/output.rs` — `compact_items`: detect trailing `?` on a field name;
    strip it for the output key; skip insertion when the value is missing or
    JSON null. Document the convention in the doc comment.
-2. `src/mcp.rs` — append `"custom_id?"` to the compact field lists of the 7
+2. `src/mcp.rs` — append `"custom_id?"` to the compact field lists of the 6
    tools above. Update tool descriptions that enumerate returned fields
    (e.g. `clickup_task_list`) to note `custom_id` is included when set.
 3. Tests:

--- a/src/mcp.rs
+++ b/src/mcp.rs
@@ -234,7 +234,7 @@ pub fn tool_list() -> Value {
         },
         {
             "name": "clickup_task_list",
-            "description": "List tasks in a specific ClickUp list with optional status/assignee filters. Returns the first page of task objects in compact form (id, name, status, assignees, due_date). Pass `page`/`limit`/`all` to paginate — when any pagination arg is provided, the response becomes `{items, pagination}` instead of a bare array. For cross-list or cross-space queries use clickup_task_search instead; for a single task use clickup_task_get.",
+            "description": "List tasks in a specific ClickUp list with optional status/assignee filters. Returns the first page of task objects in compact form (id, name, status, assignees, due_date; custom_id when the task has one). Pass `page`/`limit`/`all` to paginate — when any pagination arg is provided, the response becomes `{items, pagination}` instead of a bare array. For cross-list or cross-space queries use clickup_task_search instead; for a single task use clickup_task_get.",
             "inputSchema": {
                 "type": "object",
                 "properties": {
@@ -259,7 +259,7 @@ pub fn tool_list() -> Value {
         },
         {
             "name": "clickup_task_get",
-            "description": "Fetch the full object for a single ClickUp task — name, description, status, assignees, tags, custom fields, checklists, due date, time estimates, dependencies, and more. Returns the task object. Use clickup_task_list or clickup_task_search to find a task_id.",
+            "description": "Fetch the full object for a single ClickUp task — name, description, status, assignees, tags, custom fields, checklists, due date, time estimates, dependencies, and more. Returns the task object. Includes the task's custom_id when one is set. Use clickup_task_list or clickup_task_search to find a task_id.",
             "inputSchema": {
                 "type": "object",
                 "properties": {
@@ -337,7 +337,7 @@ pub fn tool_list() -> Value {
         },
         {
             "name": "clickup_task_search",
-            "description": "Search tasks across an entire ClickUp workspace with ClickUp's filtered team tasks endpoint. Supports hierarchy, assignee, status, tag, date range, custom field, custom item type, parent/subtask, and ordering filters. Returns a compact array of task objects. Pass `page`/`limit`/`all` to paginate — when any pagination arg is provided, the response becomes `{items, pagination}` instead of a bare array. For tasks in a single list, prefer clickup_task_list (fewer parameters, same shape).",
+            "description": "Search tasks across an entire ClickUp workspace with ClickUp's filtered team tasks endpoint. Supports hierarchy, assignee, status, tag, date range, custom field, custom item type, parent/subtask, and ordering filters. Returns a compact array of task objects (custom_id included when set). Pass `page`/`limit`/`all` to paginate — when any pagination arg is provided, the response becomes `{items, pagination}` instead of a bare array. For tasks in a single list, prefer clickup_task_list (fewer parameters, same shape).",
             "inputSchema": {
                 "type": "object",
                 "properties": {
@@ -589,7 +589,7 @@ pub fn tool_list() -> Value {
         },
         {
             "name": "clickup_view_tasks",
-            "description": "Fetch the tasks currently visible in a ClickUp view, honouring the view's configured filters, sort order, and grouping. Returns a compact array of task objects. Pass `page`/`limit`/`all` to paginate — when any pagination arg is provided, the response becomes `{items, pagination}` instead of a bare array. Use clickup_view_list to discover view IDs and clickup_view_get for the view's definition.",
+            "description": "Fetch the tasks currently visible in a ClickUp view, honouring the view's configured filters, sort order, and grouping. Returns a compact array of task objects (custom_id included when set). Pass `page`/`limit`/`all` to paginate — when any pagination arg is provided, the response becomes `{items, pagination}` instead of a bare array. Use clickup_view_list to discover view IDs and clickup_view_get for the view's definition.",
             "inputSchema": {
                 "type": "object",
                 "properties": {
@@ -2458,7 +2458,15 @@ async fn dispatch_tool(
                 &pargs,
                 client,
                 "tasks",
-                &["id", "name", "status", "priority", "assignees", "due_date"],
+                &[
+                    "id",
+                    "custom_id?",
+                    "name",
+                    "status",
+                    "priority",
+                    "assignees",
+                    "due_date",
+                ],
                 |page| {
                     let mut qs = format!("page={}", page);
                     if let Some(ic) = include_closed {
@@ -2497,6 +2505,7 @@ async fn dispatch_tool(
             let resp = client.get(&path).await.map_err(|e| e.to_string())?;
             let mut fields = vec![
                 "id",
+                "custom_id?",
                 "name",
                 "status",
                 "priority",
@@ -2545,7 +2554,15 @@ async fn dispatch_tool(
             let resp = client.post(&path, &body).await.map_err(|e| e.to_string())?;
             Ok(compact_items(
                 &[resp],
-                &["id", "name", "status", "priority", "assignees", "due_date"],
+                &[
+                    "id",
+                    "custom_id?",
+                    "name",
+                    "status",
+                    "priority",
+                    "assignees",
+                    "due_date",
+                ],
             ))
         }
 
@@ -2582,7 +2599,15 @@ async fn dispatch_tool(
             let resp = client.put(&path, &body).await.map_err(|e| e.to_string())?;
             Ok(compact_items(
                 &[resp],
-                &["id", "name", "status", "priority", "assignees", "due_date"],
+                &[
+                    "id",
+                    "custom_id?",
+                    "name",
+                    "status",
+                    "priority",
+                    "assignees",
+                    "due_date",
+                ],
             ))
         }
 
@@ -2604,7 +2629,15 @@ async fn dispatch_tool(
                 &pargs,
                 client,
                 "tasks",
-                &["id", "name", "status", "priority", "assignees", "due_date"],
+                &[
+                    "id",
+                    "custom_id?",
+                    "name",
+                    "status",
+                    "priority",
+                    "assignees",
+                    "due_date",
+                ],
                 |page| {
                     let mut parts = vec![format!("page={}", page)];
                     parts.extend(base_params.iter().cloned());
@@ -2898,7 +2931,15 @@ async fn dispatch_tool(
                 &pargs,
                 client,
                 "tasks",
-                &["id", "name", "status", "priority", "assignees", "due_date"],
+                &[
+                    "id",
+                    "custom_id?",
+                    "name",
+                    "status",
+                    "priority",
+                    "assignees",
+                    "due_date",
+                ],
                 |page| format!("/v2/view/{}/task?page={}", view_id, page),
             )
             .await

--- a/src/output.rs
+++ b/src/output.rs
@@ -90,7 +90,9 @@ impl OutputConfig {
 }
 
 /// Flatten a list of items to only include the specified fields with flattened values.
-/// Returns a JSON array. Used by MCP server for token-efficient responses.
+/// Returns a JSON array. Used by MCP server for token-efficient responses. Also
+/// reached by the CLI's `--output json-compact` mode with user-supplied `--fields`,
+/// so the trailing-`?` marker described below applies there too.
 ///
 /// A field name with a trailing `?` (e.g. `"custom_id?"`) is optional: it is
 /// emitted under the name without the marker, and only when the source value

--- a/src/output.rs
+++ b/src/output.rs
@@ -91,14 +91,29 @@ impl OutputConfig {
 
 /// Flatten a list of items to only include the specified fields with flattened values.
 /// Returns a JSON array. Used by MCP server for token-efficient responses.
+///
+/// A field name with a trailing `?` (e.g. `"custom_id?"`) is optional: it is
+/// emitted under the name without the marker, and only when the source value
+/// is present and non-null. All other fields are always emitted, with `"-"`
+/// as the placeholder for missing/null values.
 pub fn compact_items(items: &[serde_json::Value], fields: &[&str]) -> serde_json::Value {
     let compacted: Vec<serde_json::Value> = items
         .iter()
         .map(|item| {
             let mut obj = serde_json::Map::new();
             for &field in fields {
-                let val = flatten_value(item.get(field));
-                obj.insert(field.to_string(), serde_json::Value::String(val));
+                if let Some(key) = field.strip_suffix('?') {
+                    match item.get(key) {
+                        None | Some(serde_json::Value::Null) => {}
+                        Some(v) => {
+                            let val = flatten_value(Some(v));
+                            obj.insert(key.to_string(), serde_json::Value::String(val));
+                        }
+                    }
+                } else {
+                    let val = flatten_value(item.get(field));
+                    obj.insert(field.to_string(), serde_json::Value::String(val));
+                }
             }
             serde_json::Value::Object(obj)
         })

--- a/src/output.rs
+++ b/src/output.rs
@@ -50,25 +50,36 @@ impl OutputConfig {
                 println!("{}", serde_json::to_string_pretty(&filtered).unwrap());
             }
             "csv" => {
+                // Tabular output always renders every column ("-" when absent), so
+                // the optional-omission `?` marker doesn't apply here — just strip
+                // it from the header/lookup name.
+                let names: Vec<&str> = fields
+                    .iter()
+                    .map(|&f| f.strip_suffix('?').unwrap_or(f))
+                    .collect();
                 if !self.no_header {
-                    println!("{}", fields.join(","));
+                    println!("{}", names.join(","));
                 }
                 for item in items {
                     let row: Vec<String> =
-                        fields.iter().map(|&f| flatten_value(item.get(f))).collect();
+                        names.iter().map(|&f| flatten_value(item.get(f))).collect();
                     println!("{}", row.join(","));
                 }
             }
             _ => {
-                // table (default)
+                // table (default). Same `?`-stripping as csv, for the same reason.
+                let names: Vec<&str> = fields
+                    .iter()
+                    .map(|&f| f.strip_suffix('?').unwrap_or(f))
+                    .collect();
                 let mut table = Table::new();
                 table.set_content_arrangement(ContentArrangement::Dynamic);
                 if !self.no_header {
-                    table.set_header(fields.iter().map(|f| f.to_string()).collect::<Vec<_>>());
+                    table.set_header(names.iter().map(|f| f.to_string()).collect::<Vec<_>>());
                 }
                 for item in items {
                     let row: Vec<String> =
-                        fields.iter().map(|&f| flatten_value(item.get(f))).collect();
+                        names.iter().map(|&f| flatten_value(item.get(f))).collect();
                     table.add_row(row);
                 }
                 println!("{}", table);
@@ -98,6 +109,9 @@ impl OutputConfig {
 /// emitted under the name without the marker, and only when the source value
 /// is present and non-null. All other fields are always emitted, with `"-"`
 /// as the placeholder for missing/null values.
+///
+/// The trailing `?` is always interpreted as this optional marker, so a field
+/// literally named with a trailing `?` cannot be projected verbatim.
 pub fn compact_items(items: &[serde_json::Value], fields: &[&str]) -> serde_json::Value {
     let compacted: Vec<serde_json::Value> = items
         .iter()

--- a/tests/test_mcp_custom_id.rs
+++ b/tests/test_mcp_custom_id.rs
@@ -103,5 +103,8 @@ async fn task_search_includes_custom_id_when_set() {
         .write_stdin(rpc_call("clickup_task_search", serde_json::json!({})))
         .assert()
         .success()
-        .stdout(predicates::str::contains("PROJ-42"));
+        .stdout(predicates::str::contains("PROJ-42"))
+        // custom_id must appear exactly once: emitted for abc123, omitted
+        // entirely for def456 (whose custom_id is null).
+        .stdout(predicates::str::contains("custom_id").count(1));
 }

--- a/tests/test_mcp_custom_id.rs
+++ b/tests/test_mcp_custom_id.rs
@@ -108,3 +108,29 @@ async fn task_search_includes_custom_id_when_set() {
         // entirely for def456 (whose custom_id is null).
         .stdout(predicates::str::contains("custom_id").count(1));
 }
+
+#[tokio::test]
+async fn task_create_includes_custom_id_when_set() {
+    let dir = TempDir::new().unwrap();
+    let server = MockServer::start().await;
+
+    Mock::given(method("POST"))
+        .and(path_matcher("/v2/list/9/task"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "id": "new1",
+            "name": "created",
+            "custom_id": "PROJ-99",
+        })))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    mcp_serve(dir.path(), &server)
+        .write_stdin(rpc_call(
+            "clickup_task_create",
+            serde_json::json!({"list_id": "9", "name": "created"}),
+        ))
+        .assert()
+        .success()
+        .stdout(predicates::str::contains("PROJ-99"));
+}

--- a/tests/test_mcp_custom_id.rs
+++ b/tests/test_mcp_custom_id.rs
@@ -1,0 +1,107 @@
+use assert_cmd::Command;
+use predicates::prelude::*;
+use std::path::Path;
+use tempfile::TempDir;
+use wiremock::matchers::{method, path as path_matcher};
+use wiremock::{Mock, MockServer, ResponseTemplate};
+
+fn mcp_serve(dir: &Path, server: &MockServer) -> Command {
+    let mut cmd = Command::cargo_bin("clickup-cli").unwrap();
+    cmd.current_dir(dir)
+        .args(["mcp", "serve"])
+        .env("CLICKUP_API_URL", server.uri())
+        .env("CLICKUP_TOKEN", "pk_test")
+        .env("CLICKUP_WORKSPACE", "99")
+        .env_remove("CLICKUP_GIT_DETECT")
+        .env_remove("CLICKUP_TASK_ID");
+    cmd
+}
+
+fn rpc_call(tool: &str, arguments: serde_json::Value) -> String {
+    serde_json::json!({
+        "jsonrpc": "2.0",
+        "id": 1,
+        "method": "tools/call",
+        "params": {"name": tool, "arguments": arguments}
+    })
+    .to_string()
+        + "\n"
+}
+
+#[tokio::test]
+async fn task_get_includes_custom_id_when_set() {
+    let dir = TempDir::new().unwrap();
+    let server = MockServer::start().await;
+
+    Mock::given(method("GET"))
+        .and(path_matcher("/v2/task/abc123"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "id": "abc123",
+            "name": "demo",
+            "custom_id": "PROJ-42",
+            "status": {"status": "open"},
+        })))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    mcp_serve(dir.path(), &server)
+        .write_stdin(rpc_call(
+            "clickup_task_get",
+            serde_json::json!({"task_id": "abc123"}),
+        ))
+        .assert()
+        .success()
+        .stdout(predicates::str::contains("custom_id"))
+        .stdout(predicates::str::contains("PROJ-42"));
+}
+
+#[tokio::test]
+async fn task_get_omits_custom_id_when_null() {
+    let dir = TempDir::new().unwrap();
+    let server = MockServer::start().await;
+
+    Mock::given(method("GET"))
+        .and(path_matcher("/v2/task/abc123"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "id": "abc123",
+            "name": "demo",
+            "custom_id": null,
+        })))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    mcp_serve(dir.path(), &server)
+        .write_stdin(rpc_call(
+            "clickup_task_get",
+            serde_json::json!({"task_id": "abc123"}),
+        ))
+        .assert()
+        .success()
+        .stdout(predicates::str::contains("custom_id").not());
+}
+
+#[tokio::test]
+async fn task_search_includes_custom_id_when_set() {
+    let dir = TempDir::new().unwrap();
+    let server = MockServer::start().await;
+
+    Mock::given(method("GET"))
+        .and(path_matcher("/v2/team/99/task"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "tasks": [
+                {"id": "abc123", "name": "with custom", "custom_id": "PROJ-42"},
+                {"id": "def456", "name": "without custom", "custom_id": null},
+            ]
+        })))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    mcp_serve(dir.path(), &server)
+        .write_stdin(rpc_call("clickup_task_search", serde_json::json!({})))
+        .assert()
+        .success()
+        .stdout(predicates::str::contains("PROJ-42"));
+}

--- a/tests/test_output.rs
+++ b/tests/test_output.rs
@@ -1,4 +1,4 @@
-use clickup_cli::output::{flatten_value, OutputConfig};
+use clickup_cli::output::{compact_items, flatten_value, OutputConfig};
 use serde_json::json;
 
 #[test]
@@ -83,4 +83,36 @@ fn test_flatten_due_date_ms_timestamp() {
 fn test_flatten_normal_string_not_converted() {
     let val = json!("hello world");
     assert_eq!(flatten_value(Some(&val)), "hello world");
+}
+
+#[test]
+fn compact_items_includes_optional_field_when_present() {
+    let items = vec![json!({"id": "abc123", "name": "demo", "custom_id": "PROJ-42"})];
+    let result = compact_items(&items, &["id", "name", "custom_id?"]);
+    assert_eq!(result[0]["id"], json!("abc123"));
+    assert_eq!(result[0]["custom_id"], json!("PROJ-42"));
+    // The marker itself must never leak into the output.
+    assert!(result[0].get("custom_id?").is_none());
+}
+
+#[test]
+fn compact_items_omits_optional_field_when_null() {
+    let items = vec![json!({"id": "abc123", "name": "demo", "custom_id": null})];
+    let result = compact_items(&items, &["id", "name", "custom_id?"]);
+    assert!(result[0].get("custom_id").is_none());
+    assert_eq!(result[0]["name"], json!("demo"));
+}
+
+#[test]
+fn compact_items_omits_optional_field_when_missing() {
+    let items = vec![json!({"id": "abc123", "name": "demo"})];
+    let result = compact_items(&items, &["id", "name", "custom_id?"]);
+    assert!(result[0].get("custom_id").is_none());
+}
+
+#[test]
+fn compact_items_required_field_still_placeholder_when_missing() {
+    let items = vec![json!({"id": "abc123"})];
+    let result = compact_items(&items, &["id", "name"]);
+    assert_eq!(result[0]["name"], json!("-"));
 }

--- a/tests/test_output_field_marker.rs
+++ b/tests/test_output_field_marker.rs
@@ -1,0 +1,54 @@
+use assert_cmd::Command;
+use predicates::prelude::*;
+use std::path::Path;
+use tempfile::TempDir;
+use wiremock::matchers::{method, path as path_matcher};
+use wiremock::{Mock, MockServer, ResponseTemplate};
+
+fn clickup(dir: &Path, server: &MockServer) -> Command {
+    let mut cmd = Command::cargo_bin("clickup-cli").unwrap();
+    cmd.current_dir(dir)
+        .env("CLICKUP_API_URL", server.uri())
+        .env("CLICKUP_TOKEN", "pk_test")
+        .env("CLICKUP_WORKSPACE", "99")
+        .env_remove("CLICKUP_GIT_DETECT")
+        .env_remove("CLICKUP_TASK_ID");
+    cmd
+}
+
+#[tokio::test]
+async fn test_task_get_csv_strips_optional_marker_from_field_name() {
+    // `--fields "custom_id?"` uses the optional-omission marker recognized by
+    // compact_items (MCP/json-compact path). The CLI's csv/table branches must
+    // strip the trailing `?` too: the header and the looked-up key should be
+    // the clean "custom_id", not the literal "custom_id?".
+    let dir = TempDir::new().unwrap();
+    let server = MockServer::start().await;
+
+    Mock::given(method("GET"))
+        .and(path_matcher("/v2/task/abc123"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "id": "abc123",
+            "name": "demo",
+            "custom_id": "PROJ-42"
+        })))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    clickup(dir.path(), &server)
+        .args([
+            "task",
+            "get",
+            "abc123",
+            "--fields",
+            "custom_id?",
+            "--output",
+            "csv",
+        ])
+        .assert()
+        .success()
+        .stdout(predicates::str::contains("custom_id?").not())
+        .stdout(predicates::str::contains("custom_id"))
+        .stdout(predicates::str::contains("PROJ-42"));
+}


### PR DESCRIPTION
Closes #82.

## Summary

The ClickUp API already returns `custom_id` on every task object, but the MCP server dropped it: each tool projects responses through a fixed field whitelist in `compact_items`. MCP consumers therefore couldn't display or prefer custom task IDs, breaking parity with the CLI (where `--fields custom_id` / `--output json` expose it).

This PR:

- Teaches `output::compact_items` an **optional-field convention**: a field spelled with a trailing `?` (e.g. `"custom_id?"`) is emitted under the clean name only when the source value is present and non-null. Unmarked fields keep exact current behaviour (always present, `"-"` placeholder).
- Adds `"custom_id?"` to the compact field lists of the six task-returning MCP tools: `clickup_task_get`, `clickup_task_search`, `clickup_task_list`, `clickup_task_create`, `clickup_task_update`, `clickup_view_tasks` — and updates the tool descriptions that enumerate returned fields.
- `clickup_task_move` was considered but returns only a `{"message": ...}` confirmation, not a task object, so there is nothing to add a field to.

## Why omit-when-null instead of always-present?

Most workspaces don't use custom task IDs. Omitting the key keeps their responses byte-identical to today (zero token overhead), preserving the server's token-efficiency goal. **Backward compatible: purely additive.**

## No request-side changes

`custom_task_ids=true&team_id=<ws>` only affects *addressing* a task by its custom ID on input, which `resolve_task` already handles. The output field needs no query parameter.

## Testing

- Unit tests for the `?` marker in `compact_items` (present / null / missing / unmarked-field regression guard).
- New stdio integration tests (`tests/test_mcp_custom_id.rs`) drive the real `mcp serve` binary over JSON-RPC against a wiremock ClickUp API, asserting `custom_id` appears when set and is omitted when null.
- Full suite green; clippy `-D warnings` clean; fmt clean.

Design spec: `docs/superpowers/specs/2026-07-22-mcp-custom-id-design.md`
Implementation plan: `docs/superpowers/plans/2026-07-22-mcp-custom-id.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MnsYXHkHyZWDc8YrBdocsd