### PR TITLE
ci: pin deploy-aur action to commit SHA

### DIFF
--- a/.github/workflows/publish-aur.yml
+++ b/.github/workflows/publish-aur.yml
@@ -52,7 +52,7 @@ jobs:
           sed -i "s/^pkgrel=.*/pkgrel=1/" packaging/aur/PKGBUILD
 
       - name: Publish to AUR
-        uses: KSXGitHub/github-actions-deploy-aur@v4.2.0
+        uses: KSXGitHub/github-actions-deploy-aur@084b0d9b15415bf9cdb65d44dad1efe37a354050 # v4.2.0
         with:
           pkgname: clickup-cli-bin
           pkgbuild: packaging/aur/PKGBUILD


### PR DESCRIPTION
Hardening follow-up from the review of #83: `KSXGitHub/github-actions-deploy-aur` is a third-party action that receives the AUR SSH private key (`secrets.AUR_SSH_KEY`). It was pinned by mutable tag (`@v4.2.0`), which upstream could re-point after the fact.

This pins the action to the commit SHA the `v4.2.0` tag currently resolves to (`084b0d9b15415bf9cdb65d44dad1efe37a354050`, verified via the GitHub API), with a `# v4.2.0` comment so Dependabot keeps proposing pin updates.

No behavior change — same action version, immutable reference.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MnsYXHkHyZWDc8YrBdocsd