### PR TITLE
fix: time create/update panic on --start (#91)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - MCP task tools now include the task's `custom_id` in their compact responses (#82). Applies to `clickup_task_get`, `clickup_task_search`, `clickup_task_list`, `clickup_task_create`, `clickup_task_update`, and `clickup_view_tasks`. The field is only present when the task actually has a custom ID, so workspaces that don't use custom task IDs see byte-identical output (and pay no extra tokens). The ClickUp API already returns `custom_id` on task objects — no request changes; the `custom_task_ids=true` query parameter remains input-side only (addressing a task *by* its custom ID), which the MCP server already supported.
 
+### Fixed
+- `time create --start` and `time update --start` panicked during argument parsing (clap downcast panic, exit 101), making it impossible to log a time entry for a past interval (#91). The global pagination flag `--start` (Unix-ms boundary, typed `i64`) collided with the `time` subcommands' own `--start` (typed `String`); clap stored the value under one definition and read it back as the other. The pagination pair `--start` + `--start-id` is no longer global — it is now declared directly on the two commands that use it, `comment list` and `comment replies` (usage there is unchanged, and the pair is now validated as requiring each other). Behavior change: commands that don't define `--start` (e.g. `time list`, which uses `--start-date`) now reject the flag with a clap error instead of silently accepting a no-op global.
+
 ## [0.14.0] - 2026-06-24
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -83,7 +83,7 @@ clickup-cli <resource> <action> [ID] [flags]
 - `--limit N` — cap total items returned (enforced after walking, so `--all --limit 500` returns up to 500 across N pages)
 - `--page N` — manual page (v2 page-style endpoints: `task list`, `task search`, `view tasks`, `template list`)
 - `--cursor X` — manual cursor (v3 cursor-style endpoints: `doc list`, all `chat *` list commands)
-- `--start MS` + `--start-id ID` — manual boundary pair (v2 start-id-style endpoints: `comment list`, `comment replies`)
+- `--start MS` + `--start-id ID` — manual boundary pair, local to `comment list` / `comment replies` (not global; a global `--start` collided with `time create`/`time update --start`, see #91)
 - `-q` / `--quiet` — IDs only
 - `--timeout SECS` — HTTP timeout (default 30)
 

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -21,7 +21,7 @@ Pattern: `clickup-cli <resource> <action> [ID] [flags]` (or `clkup` for short)
 | `--limit N` | Cap total items returned (enforced after walking, so `--all --limit 500` returns ≤500 across N pages) |
 | `--page N` | Manual page selection (v2 page-style: `task list`, `task search`, `view tasks`, `template list`) |
 | `--cursor X` | Manual cursor (v3 cursor-style: `doc list`, all `chat *` list commands) |
-| `--start MS` + `--start-id ID` | Manual boundary pair (v2 start-id-style: `comment list`, `comment replies`) |
+| `--start MS` + `--start-id ID` | Manual boundary pair, local to `comment list` / `comment replies` (not a global flag) |
 | `--token TOKEN` | Override config file token |
 | `--workspace ID` | Override default workspace |
 | `--timeout SECS` | HTTP timeout (default 30) |

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -218,13 +218,13 @@ clickup-cli checklist delete-item <ID> <ITEM_ID>
 ## comment
 
 ```bash
-clickup-cli comment list --task <ID>          # also --list, --view
+clickup-cli comment list --task <ID> [--start MS --start-id ID]   # also --list, --view
 clickup-cli comment create --task <ID> --text TEXT [--assignee ID] [--notify-all]
 clickup-cli comment create --list <ID> --text TEXT
 clickup-cli comment create --view <ID> --text TEXT
 clickup-cli comment update <ID> --text TEXT [--resolved] [--assignee ID]
 clickup-cli comment delete <ID>
-clickup-cli comment replies <ID>              # list threaded replies
+clickup-cli comment replies <ID> [--start MS --start-id ID]        # list threaded replies
 clickup-cli comment reply <ID> --text TEXT [--assignee ID]
 ```
 

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -262,7 +262,7 @@ With `all=true` the server walks pages until natural termination:
 
 `has_more` reports purely whether the **server** has additional pages — not whether `limit` truncated the response. A `limit`-capped call with more results available still surfaces `next_cursor` / `next_start` / `next_page_timestamp` so callers who want to continue from where the server left off (rather than from where the helper cut the buffer) have what they need.
 
-The CLI side mirrors this contract on every paginated command via the same set of global flags: `--all`, `--page` / `--cursor` / `--start` + `--start-id`, and `--limit`. CLI output stays as plain table/JSON/CSV — no envelope — but pagination state is honoured identically.
+The CLI side mirrors this contract on every paginated command via the matching flags: the global `--all`, `--page`, `--cursor`, and `--limit`, plus `--start` + `--start-id` locally on the comment commands. CLI output stays as plain table/JSON/CSV — no envelope — but pagination state is honoured identically.
 
 ## How It Works
 

--- a/src/commands/comment.rs
+++ b/src/commands/comment.rs
@@ -19,6 +19,13 @@ pub enum CommentCommands {
         /// View ID
         #[arg(long, conflicts_with_all = ["task", "list"])]
         view: Option<String>,
+        /// Boundary timestamp in Unix ms for continuing a listing.
+        /// Pair with --start-id.
+        #[arg(long, requires = "start_id")]
+        start: Option<i64>,
+        /// Boundary comment id for continuing a listing. Pair with --start.
+        #[arg(long = "start-id", requires = "start")]
+        start_id: Option<String>,
     },
     /// Create a comment on a task, list, or view
     Create {
@@ -64,6 +71,13 @@ pub enum CommentCommands {
     Replies {
         /// Comment ID
         id: String,
+        /// Boundary timestamp in Unix ms for continuing a listing.
+        /// Pair with --start-id.
+        #[arg(long, requires = "start_id")]
+        start: Option<i64>,
+        /// Boundary comment id for continuing a listing. Pair with --start.
+        #[arg(long = "start-id", requires = "start")]
+        start_id: Option<String>,
     },
     /// Reply to a comment
     Reply {
@@ -86,7 +100,13 @@ pub async fn execute(command: CommentCommands, cli: &Cli) -> Result<(), CliError
     let output = OutputConfig::from_cli(&cli.output, &cli.fields, cli.no_header, cli.quiet);
 
     match command {
-        CommentCommands::List { task, list, view } => {
+        CommentCommands::List {
+            task,
+            list,
+            view,
+            start,
+            start_id,
+        } => {
             let base = if let Some(id) = list {
                 format!("/v2/list/{}/comment", id)
             } else if let Some(id) = view {
@@ -102,6 +122,8 @@ pub async fn execute(command: CommentCommands, cli: &Cli) -> Result<(), CliError
             let comments = crate::commands::pagination::walk_start_id(
                 cli,
                 &client,
+                start,
+                start_id,
                 "comments",
                 |start, start_id| match (start, start_id) {
                     (Some(s), Some(sid)) => format!("{}?start={}&start_id={}", base, s, sid),
@@ -193,10 +215,16 @@ pub async fn execute(command: CommentCommands, cli: &Cli) -> Result<(), CliError
             output.print_message(&format!("Comment {} deleted", id));
             Ok(())
         }
-        CommentCommands::Replies { id } => {
+        CommentCommands::Replies {
+            id,
+            start,
+            start_id,
+        } => {
             let comments = crate::commands::pagination::walk_start_id(
                 cli,
                 &client,
+                start,
+                start_id,
                 "comments",
                 |start, start_id| match (start, start_id) {
                     (Some(s), Some(sid)) => {

--- a/src/commands/pagination.rs
+++ b/src/commands/pagination.rs
@@ -144,12 +144,16 @@ where
 
 /// Start-id-based walker for v2 comment endpoints
 /// (`?start=<ms>&start_id=<id>` paired, response carries `{comments: [...]}`
-/// with termination inferred from short page). `build_path(Option<i64>,
-/// Option<&str>)` returns the URL given an optional boundary pair.
-/// `items_key` is the response key (typically `"comments"`).
+/// with termination inferred from short page). `start`/`start_id` are the
+/// caller's boundary pair (the comment commands' local flags — they are not
+/// global args; see issue #91). `build_path(Option<i64>, Option<&str>)`
+/// returns the URL given an optional boundary pair. `items_key` is the
+/// response key (typically `"comments"`).
 pub async fn walk_start_id<F>(
     cli: &Cli,
     client: &ClickUpClient,
+    start: Option<i64>,
+    start_id: Option<String>,
     items_key: &str,
     build_path: F,
 ) -> Result<Vec<Value>, CliError>
@@ -157,8 +161,8 @@ where
     F: Fn(Option<i64>, Option<&str>) -> String,
 {
     const PAGE_HINT: usize = 25;
-    let mut current_start = cli.start;
-    let mut current_start_id = cli.start_id.clone();
+    let mut current_start = start;
+    let mut current_start_id = start_id;
     let mut collected: Vec<Value> = Vec::new();
     let mut pages_fetched = 0usize;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -51,16 +51,6 @@ pub struct Cli {
     #[arg(long, global = true)]
     pub cursor: Option<String>,
 
-    /// Boundary timestamp in Unix ms (v2 start-id-based comment endpoints).
-    /// Pair with --start-id; both required when continuing a comment listing.
-    #[arg(long, global = true)]
-    pub start: Option<i64>,
-
-    /// Boundary comment id (v2 start-id-based comment endpoints).
-    /// Pair with --start.
-    #[arg(long = "start-id", global = true)]
-    pub start_id: Option<String>,
-
     /// Only print IDs, one per line
     #[arg(short, long, global = true)]
     pub quiet: bool,

--- a/tests/test_time_start_args.rs
+++ b/tests/test_time_start_args.rs
@@ -1,0 +1,158 @@
+//! Regression tests for issue #91: `time create`/`time update` panicked on
+//! `--start` because the global pagination `--start` (i64) collided with the
+//! subcommands' local `--start` (String). The pagination pair `--start` /
+//! `--start-id` is now scoped to the comment commands that actually use it.
+
+use assert_cmd::Command;
+use std::path::Path;
+use tempfile::TempDir;
+use wiremock::matchers::{method, path as path_matcher, query_param};
+use wiremock::{Mock, MockServer, ResponseTemplate};
+
+fn clickup(dir: &Path, server: &MockServer) -> Command {
+    let mut cmd = Command::cargo_bin("clickup-cli").unwrap();
+    cmd.current_dir(dir)
+        .env("CLICKUP_API_URL", server.uri())
+        .env("CLICKUP_TOKEN", "pk_test")
+        .env("CLICKUP_WORKSPACE", "99")
+        .env("CLICKUP_GIT_DETECT", "0")
+        .env_remove("CLICKUP_TASK_ID");
+    cmd
+}
+
+/// The clap command definition must be internally consistent. This is the
+/// startup-time check that would have caught the global/local `--start`
+/// type collision before release.
+#[test]
+fn clap_command_definition_is_consistent() {
+    use clap::CommandFactory;
+    clickup_cli::Cli::command().debug_assert();
+}
+
+#[tokio::test]
+async fn time_create_accepts_start() {
+    let dir = TempDir::new().unwrap();
+    let server = MockServer::start().await;
+
+    Mock::given(method("POST"))
+        .and(path_matcher("/v2/team/99/time_entries"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "data": {"id": "et1", "start": "1753800000000", "duration": 3600000}
+        })))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    clickup(dir.path(), &server)
+        .args([
+            "time",
+            "create",
+            "--start",
+            "1753800000000",
+            "--duration",
+            "3600000",
+        ])
+        .assert()
+        .success()
+        .stdout(predicates::str::contains("et1"));
+}
+
+#[tokio::test]
+async fn time_update_accepts_start() {
+    let dir = TempDir::new().unwrap();
+    let server = MockServer::start().await;
+
+    Mock::given(method("PUT"))
+        .and(path_matcher("/v2/team/99/time_entries/et1"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "data": {"id": "et1", "start": "1753800000000"}
+        })))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    clickup(dir.path(), &server)
+        .args(["time", "update", "et1", "--start", "1753800000000"])
+        .assert()
+        .success()
+        .stdout(predicates::str::contains("et1"));
+}
+
+/// The pagination boundary pair must keep working on the comment commands
+/// after being de-globalized.
+#[tokio::test]
+async fn comment_list_still_passes_start_boundary_pair() {
+    let dir = TempDir::new().unwrap();
+    let server = MockServer::start().await;
+
+    Mock::given(method("GET"))
+        .and(path_matcher("/v2/task/t1/comment"))
+        .and(query_param("start", "1700000000000"))
+        .and(query_param("start_id", "c9"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "comments": [{"id": "c10", "comment_text": "hi", "date": "1700000000001"}]
+        })))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    clickup(dir.path(), &server)
+        .args([
+            "comment",
+            "list",
+            "--task",
+            "t1",
+            "--start",
+            "1700000000000",
+            "--start-id",
+            "c9",
+        ])
+        .assert()
+        .success()
+        .stdout(predicates::str::contains("c10"));
+}
+
+#[tokio::test]
+async fn comment_replies_still_pass_start_boundary_pair() {
+    let dir = TempDir::new().unwrap();
+    let server = MockServer::start().await;
+
+    Mock::given(method("GET"))
+        .and(path_matcher("/v2/comment/c1/reply"))
+        .and(query_param("start", "1700000000000"))
+        .and(query_param("start_id", "c9"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "comments": [{"id": "c10", "comment_text": "re", "date": "1700000000001"}]
+        })))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    clickup(dir.path(), &server)
+        .args([
+            "comment",
+            "replies",
+            "c1",
+            "--start",
+            "1700000000000",
+            "--start-id",
+            "c9",
+        ])
+        .assert()
+        .success()
+        .stdout(predicates::str::contains("c10"));
+}
+
+/// `--start` is no longer a global flag, so commands without their own
+/// `--start` must reject it instead of silently accepting a no-op.
+#[tokio::test]
+async fn time_list_rejects_start_flag() {
+    let dir = TempDir::new().unwrap();
+    let server = MockServer::start().await;
+
+    clickup(dir.path(), &server)
+        .args(["time", "list", "--start", "1700000000000"])
+        .assert()
+        .failure()
+        .stderr(predicates::str::contains("unexpected argument"));
+}

--- a/tests/test_time_start_args.rs
+++ b/tests/test_time_start_args.rs
@@ -20,9 +20,10 @@ fn clickup(dir: &Path, server: &MockServer) -> Command {
     cmd
 }
 
-/// The clap command definition must be internally consistent. This is the
-/// startup-time check that would have caught the global/local `--start`
-/// type collision before release.
+/// General clap self-consistency check. Note: this does NOT catch
+/// global/local same-name type collisions like issue #91 (those fail only
+/// at access time) — the wiremock behavior tests below are the real
+/// regression guard for that class of bug.
 #[test]
 fn clap_command_definition_is_consistent() {
     use clap::CommandFactory;
@@ -147,6 +148,8 @@ async fn comment_replies_still_pass_start_boundary_pair() {
 /// `--start` must reject it instead of silently accepting a no-op.
 #[tokio::test]
 async fn time_list_rejects_start_flag() {
+    // Parse-level rejection: no HTTP call is ever made, but the helper
+    // still needs a server URI for the env template.
     let dir = TempDir::new().unwrap();
     let server = MockServer::start().await;
 


### PR DESCRIPTION
Fixes #91.

## Root cause

The top-level CLI declared `--start` as a **global** clap arg typed `Option<i64>` (the v2 comment-pagination boundary). Global args propagate into every subcommand — including `time create` and `time update`, which declare their own local `--start` as `String`. clap stored the parsed value under the subcommand's String definition, then the top-level derive read `start` back as `i64` and panicked on the downcast (exit 101), before any network call. `time list` "worked" only because it has no local `--start` — it silently accepted the useless global flag. Same-name shadowing with a *matching* type (e.g. `agent-config init --workspace`) doesn't panic, which is why only the `time` commands were affected.

## Fix — remove the collision at the source

`--start`/`--start-id` were only ever consumed by `walk_start_id`, used by exactly two commands. They are no longer global:

- Declared locally on `comment list` and `comment replies` (usage unchanged), now with `requires` linking the pair, matching the documented "both required" contract.
- `walk_start_id` takes the boundary pair explicitly instead of reading it off the global `Cli`.
- `time create --start <ms> --duration <ms>` and `time update <id> --start <ms>` now work as documented.
- Every other command's `--help` loses two irrelevant pagination flags.

**Behavior change:** commands without their own `--start` (e.g. `time list`, which uses `--start-date`) now reject `--start` with a normal clap error instead of silently accepting a no-op. Noted in the changelog.

## On the issue's `debug_assert` suggestion

We added a `Cli::command().debug_assert()` test, but notably it **passes even with the collision present** — the mismatch is an access-time (derive) error, not a definition-time one, so clap's self-check can't catch this class. The real regression guards are the new behavior tests.

## Testing (TDD — failing tests written first, watched fail with the panic)

New `tests/test_time_start_args.rs` (wiremock end-to-end through the real binary):
- `time create --start`/`time update --start` succeed (previously: clap panic, exit 101)
- `comment list` / `comment replies` still send the `start`/`start_id` boundary query params
- `time list --start` now errors cleanly
- clap definition self-check (`debug_assert`)

Full suite green; clippy `-D warnings` clean; fmt clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MnsYXHkHyZWDc8YrBdocsd