### PR TITLE
release: v0.15.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.15.0] - 2026-08-05
+
 ### Added
 - MCP task tools now include the task's `custom_id` in their compact responses (#82). Applies to `clickup_task_get`, `clickup_task_search`, `clickup_task_list`, `clickup_task_create`, `clickup_task_update`, and `clickup_view_tasks`. The field is only present when the task actually has a custom ID, so workspaces that don't use custom task IDs see byte-identical output (and pay no extra tokens). The ClickUp API already returns `custom_id` on task objects — no request changes; the `custom_task_ids=true` query parameter remains input-side only (addressing a task *by* its custom ID), which the MCP server already supported.
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -276,7 +276,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "clickup-cli"
-version = "0.14.0"
+version = "0.15.0"
 dependencies = [
  "assert_cmd",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "clickup-cli"
-version = "0.14.0"
+version = "0.15.0"
 edition = "2021"
 rust-version = "1.88"
 description = "CLI for the ClickUp API, optimized for AI agents"

--- a/npm/package.json
+++ b/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nick.bester/clickup-cli",
-  "version": "0.14.0",
+  "version": "0.15.0",
   "description": "CLI for the ClickUp API, optimized for AI agents",
   "license": "Apache-2.0",
   "author": "Nick Bester <1872093+nicholasbester@users.noreply.github.com> (https://github.com/nicholasbester)",


### PR DESCRIPTION
Bump to 0.15.0 and roll CHANGELOG. Tagging v0.15.0 after merge triggers the release pipeline.

## In this release

- **Added:** MCP task tools include `custom_id` in compact responses when set (#82, PR #86)
- **Fixed:** `time create`/`time update` panic on `--start` — pagination `--start`/`--start-id` de-globalized to the comment commands (#91, PR #92)

## Post-tag verification notes

This is the first release exercising two workflow changes that PR CI never runs:
- `actions/setup-node@v7` in the npm publish path (#84)
- SHA-pinned `github-actions-deploy-aur` (#89)

Both were reviewed as low-risk, but the npm and AUR publish jobs should be watched on this tag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MnsYXHkHyZWDc8YrBdocsd