### PR TITLE
fix: auto-correct swapped field/task positionals in field set/unset (#96)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- `field set` / `field unset` invoked with the two positionals in the natural API order (`<task_id> <field_uuid>` instead of the CLI's `<FIELD_ID> [TASK_ID]`) silently built the request URL with the IDs reversed, which ClickUp answers with a misleading 401 "Team not authorized" (#96). Field IDs are always UUIDs and task IDs never are, so the swap is unambiguous: the CLI now detects it, reinterprets the arguments, and prints a `note: arguments looked swapped …` breadcrumb to stderr. The documented order and the git-branch auto-detect path are unchanged; when both arguments are UUIDs the input is used exactly as given.
+
 ## [0.15.0] - 2026-08-05
 
 ### Added

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -258,7 +258,7 @@ Custom fields on tasks.
 ```bash
 clickup-cli field list --list <ID>            # also --folder, --space, --workspace-level
 clickup-cli field set <FIELD_ID> --value VALUE [TASK_ID]
-clickup-cli field unset <FIELD_ID> [TASK_ID]
+clickup-cli field unset <FIELD_ID> [TASK_ID]   # swapped order is auto-corrected with a stderr note
 ```
 
 Value can be a string, number, or JSON for complex field types. For `drop_down`, use the option ID from the field's `type_config.options`; for `labels`, pass a JSON array of option IDs.

--- a/src/commands/field.rs
+++ b/src/commands/field.rs
@@ -45,6 +45,34 @@ pub enum FieldCommands {
 
 const FIELD_FIELDS: &[&str] = &["id", "name", "type", "required"];
 
+/// ClickUp custom-field IDs are UUIDs; task IDs never are (short
+/// alphanumeric or `PREFIX-42` custom IDs). When the two positionals arrive
+/// in the natural API order (task first) instead of the CLI's
+/// `<FIELD_ID> [TASK_ID]`, reinterpret them and leave a breadcrumb on
+/// stderr — otherwise the reversed URL draws a misleading
+/// 401 "Team not authorized" from ClickUp (issue #96).
+fn maybe_unswap(field_id: String, task_id: Option<String>) -> (String, Option<String>) {
+    match task_id {
+        Some(t) if is_uuid(&t) && !is_uuid(&field_id) => {
+            eprintln!(
+                "note: arguments looked swapped (field IDs are UUIDs); using '{}' as the field and '{}' as the task",
+                t, field_id
+            );
+            (t, Some(field_id))
+        }
+        other => (field_id, other),
+    }
+}
+
+fn is_uuid(s: &str) -> bool {
+    let parts: Vec<&str> = s.split('-').collect();
+    parts.len() == 5
+        && [8usize, 4, 4, 4, 12]
+            .iter()
+            .zip(&parts)
+            .all(|(len, p)| p.len() == *len && p.chars().all(|c| c.is_ascii_hexdigit()))
+}
+
 pub async fn execute(command: FieldCommands, cli: &Cli) -> Result<(), CliError> {
     let token = resolve_token(cli)?;
     let client = ClickUpClient::new(&token, cli.timeout)?;
@@ -87,6 +115,7 @@ pub async fn execute(command: FieldCommands, cli: &Cli) -> Result<(), CliError> 
             field_id,
             value,
         } => {
+            let (field_id, task_id) = maybe_unswap(field_id, task_id);
             let task = git::require_task(cli, task_id.as_deref(), true)?;
             // Try to parse value as JSON first, fallback to string
             let parsed_value: serde_json::Value =
@@ -99,6 +128,7 @@ pub async fn execute(command: FieldCommands, cli: &Cli) -> Result<(), CliError> 
             Ok(())
         }
         FieldCommands::Unset { task_id, field_id } => {
+            let (field_id, task_id) = maybe_unswap(field_id, task_id);
             let task = git::require_task(cli, task_id.as_deref(), true)?;
             client
                 .delete(&format!("/v2/task/{}/field/{}", task.id, field_id))
@@ -106,5 +136,49 @@ pub async fn execute(command: FieldCommands, cli: &Cli) -> Result<(), CliError> 
             output.print_message(&format!("Field {} cleared on task {}", field_id, task.raw));
             Ok(())
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn uuid_shape_is_recognized() {
+        assert!(is_uuid("b955c4dc-b8a8-48d8-a0c6-b4200788a683"));
+        assert!(is_uuid("B955C4DC-B8A8-48D8-A0C6-B4200788A683"));
+    }
+
+    #[test]
+    fn task_id_shapes_are_not_uuids() {
+        assert!(!is_uuid("86czkjbtq"));
+        assert!(!is_uuid("PROJ-42"));
+        assert!(!is_uuid("b955c4dc-b8a8-48d8-a0c6")); // too few segments
+        assert!(!is_uuid("b955c4dc-b8a8-48d8-a0c6-b4200788a68z")); // non-hex
+        assert!(!is_uuid("b955c4dcb8a848d8a0c6b4200788a683")); // no dashes
+    }
+
+    #[test]
+    fn unswap_only_when_unambiguous() {
+        // Swapped: task slot holds the UUID.
+        let (f, t) = maybe_unswap(
+            "86czkjbtq".into(),
+            Some("b955c4dc-b8a8-48d8-a0c6-b4200788a683".into()),
+        );
+        assert_eq!(f, "b955c4dc-b8a8-48d8-a0c6-b4200788a683");
+        assert_eq!(t.as_deref(), Some("86czkjbtq"));
+
+        // Correct order: untouched.
+        let (f, t) = maybe_unswap(
+            "b955c4dc-b8a8-48d8-a0c6-b4200788a683".into(),
+            Some("86czkjbtq".into()),
+        );
+        assert_eq!(f, "b955c4dc-b8a8-48d8-a0c6-b4200788a683");
+        assert_eq!(t.as_deref(), Some("86czkjbtq"));
+
+        // No task arg (git auto-detect path): untouched.
+        let (f, t) = maybe_unswap("86czkjbtq".into(), None);
+        assert_eq!(f, "86czkjbtq");
+        assert_eq!(t, None);
     }
 }

--- a/src/commands/field.rs
+++ b/src/commands/field.rs
@@ -54,6 +54,9 @@ const FIELD_FIELDS: &[&str] = &["id", "name", "type", "required"];
 fn maybe_unswap(field_id: String, task_id: Option<String>) -> (String, Option<String>) {
     match task_id {
         Some(t) if is_uuid(&t) && !is_uuid(&field_id) => {
+            // Deliberately unconditional (not gated on -q/output mode like
+            // the branch-detect breadcrumb): this note reports that the
+            // request semantics were changed, not routine resolution.
             eprintln!(
                 "note: arguments looked swapped (field IDs are UUIDs); using '{}' as the field and '{}' as the task",
                 t, field_id

--- a/tests/test_field_swap.rs
+++ b/tests/test_field_swap.rs
@@ -1,0 +1,120 @@
+//! Regression tests for issue #96: `field unset <task_id> <field_uuid>`
+//! (arguments in the natural API order, but swapped relative to the CLI's
+//! `<FIELD_ID> [TASK_ID]` signature) built a URL with the IDs reversed and
+//! surfaced ClickUp's misleading 401 "Team not authorized". Field IDs are
+//! always UUIDs and task IDs never are, so the swap is detected and the
+//! arguments are reinterpreted, with a breadcrumb on stderr.
+
+use assert_cmd::Command;
+use std::path::Path;
+use tempfile::TempDir;
+use wiremock::matchers::{method, path as path_matcher};
+use wiremock::{Mock, MockServer, ResponseTemplate};
+
+const FIELD_UUID: &str = "b955c4dc-b8a8-48d8-a0c6-b4200788a683";
+const TASK_ID: &str = "86czkjbtq";
+
+fn clickup(dir: &Path, server: &MockServer) -> Command {
+    let mut cmd = Command::cargo_bin("clickup-cli").unwrap();
+    cmd.current_dir(dir)
+        .env("CLICKUP_API_URL", server.uri())
+        .env("CLICKUP_TOKEN", "pk_test")
+        .env("CLICKUP_WORKSPACE", "99")
+        .env("CLICKUP_GIT_DETECT", "0")
+        .env_remove("CLICKUP_TASK_ID");
+    cmd
+}
+
+#[tokio::test]
+async fn field_unset_swapped_args_are_corrected_with_breadcrumb() {
+    let dir = TempDir::new().unwrap();
+    let server = MockServer::start().await;
+
+    // The mock only matches the CORRECT url (task in the task slot).
+    Mock::given(method("DELETE"))
+        .and(path_matcher(format!(
+            "/v2/task/{}/field/{}",
+            TASK_ID, FIELD_UUID
+        )))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({})))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    // Issue #96 invocation: task first, field UUID second.
+    clickup(dir.path(), &server)
+        .args(["field", "unset", TASK_ID, FIELD_UUID])
+        .assert()
+        .success()
+        .stderr(predicates::str::contains("swapped"));
+}
+
+#[tokio::test]
+async fn field_set_swapped_args_are_corrected_with_breadcrumb() {
+    let dir = TempDir::new().unwrap();
+    let server = MockServer::start().await;
+
+    Mock::given(method("POST"))
+        .and(path_matcher(format!(
+            "/v2/task/{}/field/{}",
+            TASK_ID, FIELD_UUID
+        )))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({})))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    clickup(dir.path(), &server)
+        .args(["field", "set", TASK_ID, "--value", "5", FIELD_UUID])
+        .assert()
+        .success()
+        .stderr(predicates::str::contains("swapped"));
+}
+
+#[tokio::test]
+async fn field_unset_documented_order_unchanged_no_breadcrumb() {
+    let dir = TempDir::new().unwrap();
+    let server = MockServer::start().await;
+
+    Mock::given(method("DELETE"))
+        .and(path_matcher(format!(
+            "/v2/task/{}/field/{}",
+            TASK_ID, FIELD_UUID
+        )))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({})))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    clickup(dir.path(), &server)
+        .args(["field", "unset", FIELD_UUID, TASK_ID])
+        .assert()
+        .success()
+        .stderr(predicates::str::contains("swapped").not());
+}
+
+/// Two UUIDs is ambiguous — no reinterpretation, args used as given.
+#[tokio::test]
+async fn field_unset_both_uuids_not_swapped() {
+    let dir = TempDir::new().unwrap();
+    let server = MockServer::start().await;
+    let other_uuid = "0f6e2a4e-1111-4222-8333-444455556666";
+
+    Mock::given(method("DELETE"))
+        .and(path_matcher(format!(
+            "/v2/task/{}/field/{}",
+            other_uuid, FIELD_UUID
+        )))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({})))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    clickup(dir.path(), &server)
+        .args(["field", "unset", FIELD_UUID, other_uuid])
+        .assert()
+        .success()
+        .stderr(predicates::str::contains("swapped").not());
+}
+
+use predicates::prelude::*;

--- a/tests/test_field_swap.rs
+++ b/tests/test_field_swap.rs
@@ -6,6 +6,7 @@
 //! arguments are reinterpreted, with a breadcrumb on stderr.
 
 use assert_cmd::Command;
+use predicates::prelude::*;
 use std::path::Path;
 use tempfile::TempDir;
 use wiremock::matchers::{method, path as path_matcher};
@@ -116,5 +117,3 @@ async fn field_unset_both_uuids_not_swapped() {
         .success()
         .stderr(predicates::str::contains("swapped").not());
 }
-
-use predicates::prelude::*;


### PR DESCRIPTION
Fixes #96.

## Root cause — not an auth bug

`field unset` takes `<FIELD_ID> [TASK_ID]` (field first — the optional git-auto-detected task must be the trailing positional). The report invoked it in the natural API order, `field unset <task_id> <field_uuid>`, so the CLI sent `DELETE /v2/task/<field_uuid>/field/<task_id>` — IDs reversed. ClickUp responds to task IDs that don't map to an authorized team with **401 "Team not authorized"** rather than 404, and the CLI's 401 hint ("check your API token") pointed at exactly the wrong thing. The raw `curl` in the report succeeded because it used the correct URL order. `field set` shared the same trap, as the report guessed.

## Fix

The two ID shapes are unambiguous — ClickUp field IDs are always UUIDs, task IDs never are (short alphanumeric like `86czkjbtq`, or `PROJ-42` custom IDs). `field set`/`field unset` now detect the swapped pattern (UUID in the task slot, non-UUID in the field slot), reinterpret the arguments, and print a breadcrumb to stderr:

```
note: arguments looked swapped (field IDs are UUIDs); using 'b955c4dc-…' as the field and '86czkjbtq' as the task
```

- Documented order: unchanged, no breadcrumb.
- Both args UUIDs (ambiguous): used exactly as given.
- Git auto-detect path (no task arg): unchanged.
- Arg order itself is untouched — no breaking change.

## Testing (TDD — watched the swap tests fail against a mock that only matches the corrected URL)

- `tests/test_field_swap.rs` (wiremock, end-to-end through the binary): swapped `unset`/`set` now hit the correct URL with the stderr note; documented order and both-UUIDs cases are untouched with no note.
- Unit tests for the UUID-shape check (case-insensitivity, segment counts, non-hex, `PROJ-42`).

Full suite green; clippy `-D warnings` clean; fmt clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MnsYXHkHyZWDc8YrBdocsd