### PR TITLE
release: v0.15.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.15.1] - 2026-08-13
+
 ### Fixed
 - `field set` / `field unset` invoked with the two positionals in the natural API order (`<task_id> <field_uuid>` instead of the CLI's `<FIELD_ID> [TASK_ID]`) silently built the request URL with the IDs reversed, which ClickUp answers with a misleading 401 "Team not authorized" (#96). Field IDs are always UUIDs and task IDs never are, so the swap is unambiguous: the CLI now detects it, reinterprets the arguments, and prints a `note: arguments looked swapped …` breadcrumb to stderr. The documented order and the git-branch auto-detect path are unchanged; when both arguments are UUIDs the input is used exactly as given.
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -276,7 +276,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "clickup-cli"
-version = "0.15.0"
+version = "0.15.1"
 dependencies = [
  "assert_cmd",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "clickup-cli"
-version = "0.15.0"
+version = "0.15.1"
 edition = "2021"
 rust-version = "1.88"
 description = "CLI for the ClickUp API, optimized for AI agents"

--- a/npm/package.json
+++ b/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nick.bester/clickup-cli",
-  "version": "0.15.0",
+  "version": "0.15.1",
   "description": "CLI for the ClickUp API, optimized for AI agents",
   "license": "Apache-2.0",
   "author": "Nick Bester <1872093+nicholasbester@users.noreply.github.com> (https://github.com/nicholasbester)",


### PR DESCRIPTION
Bump to 0.15.1 and roll CHANGELOG. Tagging v0.15.1 after merge triggers the release pipeline.

## In this release

- **Fixed:** `field set`/`field unset` auto-correct swapped field/task positionals instead of surfacing ClickUp's misleading 401 "Team not authorized" (#96, PR #97)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MnsYXHkHyZWDc8YrBdocsd