### PR TITLE
release: v0.15.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.15.2] - 2026-08-14
+
 ### Fixed
 - Custom-format task IDs (`PROJ-42`) now work on every task-scoped `/v2/task/{id}/...` command, not just `task get/update/delete` and `doc embed-image` (#98). `field set`/`unset`, `comment list`/`create`, `checklist create`, `member list`, `attachment upload`/`list`, `task add-tag`/`remove-tag`/`add-dep`/`remove-dep`, and the auto-detected single-ID path of `task time-in-status` previously dropped the `custom_task_ids=true&team_id=<ws>` query pair, so a custom ID drew ClickUp's misleading 401 "Team not authorized". The pair is now appended by a shared helper (`custom_task_query`), which the existing hand-rolled copies in `task.rs`/`doc.rs` also use; regular task IDs produce byte-identical requests. When a custom ID is used with no workspace configured, the CLI fails locally with the setup hint instead of sending a request ClickUp will reject. Not covered: `time list/create/start --task` (task IDs go to team-scoped endpoints via a different mechanism) and explicit IDs passed to `task time-in-status`/`task link`/`task unlink`/`guest share-task`/`guest unshare-task` (passed through verbatim, as before). One inherent API semantic worth knowing: ClickUp applies `custom_task_ids=true` to every ID in the request, so e.g. `task add-dep PROJ-42 --depends-on <plain_id>` asks ClickUp to interpret the body ID as custom too — mixing ID styles in one call may not resolve (previously the same call was a guaranteed 401, so this is strictly no worse).
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -276,7 +276,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "clickup-cli"
-version = "0.15.1"
+version = "0.15.2"
 dependencies = [
  "assert_cmd",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "clickup-cli"
-version = "0.15.1"
+version = "0.15.2"
 edition = "2021"
 rust-version = "1.88"
 description = "CLI for the ClickUp API, optimized for AI agents"

--- a/npm/package.json
+++ b/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nick.bester/clickup-cli",
-  "version": "0.15.1",
+  "version": "0.15.2",
   "description": "CLI for the ClickUp API, optimized for AI agents",
   "license": "Apache-2.0",
   "author": "Nick Bester <1872093+nicholasbester@users.noreply.github.com> (https://github.com/nicholasbester)",


### PR DESCRIPTION
Bump to 0.15.2 and roll CHANGELOG. Tagging v0.15.2 after merge triggers the release pipeline.

## In this release

- **Fixed:** custom-format task IDs (`PROJ-42`) now carry the `custom_task_ids=true&team_id` pair on all task-scoped `/v2/task/{id}/…` commands — field, comment, checklist, member, attachment, task tag/dep, and auto-detected `time-in-status` (#98, PR #100)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MnsYXHkHyZWDc8YrBdocsd