### PR TITLE
fix(mcp): route member_list task_id through resolve_task (#101)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- MCP: `clickup_member_list` now routes `task_id` through the same `resolve_task` handling as every other task-scoped MCP tool (#101). Previously it passed the ID raw into `/v2/task/{id}/member`, so custom-format IDs (`PROJ-42`) drew ClickUp's misleading 401 "Team not authorized" and explicit `CU-` prefixes were not stripped. `clickup_guest_share_task`/`unshare_task` keep taking raw IDs, matching their CLI twins.
+
 ## [0.15.2] - 2026-08-14
 
 ### Fixed

--- a/src/mcp.rs
+++ b/src/mcp.rs
@@ -3054,6 +3054,8 @@ async fn dispatch_tool(
         }
 
         "clickup_member_list" => {
+            // Presence is pre-checked so resolve_task's missing-param error
+            // is unreachable and the list_id/neither branches are untouched.
             let path = if args.get("task_id").and_then(|v| v.as_str()).is_some() {
                 let (task_id, custom_q) = resolve_task(args, "task_id")?;
                 match custom_q {

--- a/src/mcp.rs
+++ b/src/mcp.rs
@@ -3054,8 +3054,12 @@ async fn dispatch_tool(
         }
 
         "clickup_member_list" => {
-            let path = if let Some(task_id) = args.get("task_id").and_then(|v| v.as_str()) {
-                format!("/v2/task/{}/member", task_id)
+            let path = if args.get("task_id").and_then(|v| v.as_str()).is_some() {
+                let (task_id, custom_q) = resolve_task(args, "task_id")?;
+                match custom_q {
+                    Some(q) => format!("/v2/task/{}/member?{}", task_id, q),
+                    None => format!("/v2/task/{}/member", task_id),
+                }
             } else if let Some(list_id) = args.get("list_id").and_then(|v| v.as_str()) {
                 format!("/v2/list/{}/member", list_id)
             } else {

--- a/tests/test_mcp_member_list.rs
+++ b/tests/test_mcp_member_list.rs
@@ -92,8 +92,12 @@ async fn member_list_cu_prefix_is_stripped() {
     let dir = TempDir::new().unwrap();
     let server = MockServer::start().await;
 
+    // path_matcher ignores query strings, so explicitly pin that CU-abc123
+    // is not misclassified as a custom ID (which would append the pair).
     Mock::given(method("GET"))
         .and(path_matcher("/v2/task/abc123/member"))
+        .and(query_param_is_missing("custom_task_ids"))
+        .and(query_param_is_missing("team_id"))
         .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
             "members": []
         })))

--- a/tests/test_mcp_member_list.rs
+++ b/tests/test_mcp_member_list.rs
@@ -1,0 +1,111 @@
+//! Regression tests for issue #101: the MCP `clickup_member_list` tool passed
+//! `task_id` raw into `/v2/task/{id}/member`, skipping the `resolve_task`
+//! handling every sibling task-scoped MCP handler uses — so custom-format IDs
+//! (`PROJ-42`) drew ClickUp's misleading 401 "Team not authorized" and `CU-`
+//! prefixes were not stripped.
+
+use assert_cmd::Command;
+use std::path::Path;
+use tempfile::TempDir;
+use wiremock::matchers::{method, path as path_matcher, query_param, query_param_is_missing};
+use wiremock::{Mock, MockServer, ResponseTemplate};
+
+fn mcp_serve(dir: &Path, server: &MockServer) -> Command {
+    let mut cmd = Command::cargo_bin("clickup-cli").unwrap();
+    cmd.current_dir(dir)
+        .args(["mcp", "serve"])
+        .env("CLICKUP_API_URL", server.uri())
+        .env("CLICKUP_TOKEN", "pk_test")
+        .env("CLICKUP_WORKSPACE", "99")
+        .env_remove("CLICKUP_GIT_DETECT")
+        .env_remove("CLICKUP_TASK_ID");
+    cmd
+}
+
+fn rpc_call(tool: &str, arguments: serde_json::Value) -> String {
+    serde_json::json!({
+        "jsonrpc": "2.0",
+        "id": 1,
+        "method": "tools/call",
+        "params": {"name": tool, "arguments": arguments}
+    })
+    .to_string()
+        + "\n"
+}
+
+#[tokio::test]
+async fn member_list_custom_task_id_appends_pair() {
+    let dir = TempDir::new().unwrap();
+    let server = MockServer::start().await;
+
+    Mock::given(method("GET"))
+        .and(path_matcher("/v2/task/PROJ-42/member"))
+        .and(query_param("custom_task_ids", "true"))
+        .and(query_param("team_id", "99"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "members": [{"id": 1, "username": "nick", "email": "n@x.com"}]
+        })))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    mcp_serve(dir.path(), &server)
+        .write_stdin(rpc_call(
+            "clickup_member_list",
+            serde_json::json!({"task_id": "PROJ-42"}),
+        ))
+        .assert()
+        .success()
+        .stdout(predicates::str::contains("nick"));
+}
+
+#[tokio::test]
+async fn member_list_plain_task_id_omits_pair() {
+    let dir = TempDir::new().unwrap();
+    let server = MockServer::start().await;
+
+    Mock::given(method("GET"))
+        .and(path_matcher("/v2/task/86czkjbtq/member"))
+        .and(query_param_is_missing("custom_task_ids"))
+        .and(query_param_is_missing("team_id"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "members": [{"id": 1, "username": "nick", "email": "n@x.com"}]
+        })))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    mcp_serve(dir.path(), &server)
+        .write_stdin(rpc_call(
+            "clickup_member_list",
+            serde_json::json!({"task_id": "86czkjbtq"}),
+        ))
+        .assert()
+        .success()
+        .stdout(predicates::str::contains("nick"));
+}
+
+/// `CU-` prefixes are stripped by resolve_task on every sibling handler;
+/// member_list must behave the same.
+#[tokio::test]
+async fn member_list_cu_prefix_is_stripped() {
+    let dir = TempDir::new().unwrap();
+    let server = MockServer::start().await;
+
+    Mock::given(method("GET"))
+        .and(path_matcher("/v2/task/abc123/member"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "members": []
+        })))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    mcp_serve(dir.path(), &server)
+        .write_stdin(rpc_call(
+            "clickup_member_list",
+            serde_json::json!({"task_id": "CU-abc123"}),
+        ))
+        .assert()
+        .success();
+}


### PR DESCRIPTION
Fixes #101.

`clickup_member_list` was the one resolver-eligible MCP handler passing `task_id` raw into its `/v2/task/{id}/…` path (verified by sweeping every `format!("/v2/task/` site in mcp.rs — all others either use the `resolve_task` closure's `(id, Option<query>)` pair or are `guest share/unshare-task`, which take raw IDs by design matching their CLI twins). Custom-format IDs drew the misleading 401 "Team not authorized" and `CU-` prefixes weren't stripped.

The task branch now uses the same `resolve_task` closure as the sibling handlers: custom IDs get `custom_task_ids=true&team_id=<ws>`, `CU-` prefixes are stripped, plain IDs are byte-identical (guarded by test).

## Testing (TDD — watched the custom-ID and CU-prefix tests fail first)

`tests/test_mcp_member_list.rs` drives the real `mcp serve` binary over JSON-RPC stdio against wiremock: custom ID appends the pair, plain ID omits it (`query_param_is_missing`), `CU-` prefix is stripped.

Full suite green (25 binaries); clippy `-D warnings` clean; fmt clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MnsYXHkHyZWDc8YrBdocsd