### PR TITLE
ci: bump release job Node to 24 so npm@latest can run (#105)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -160,7 +160,7 @@ jobs:
         if: ${{ !contains(github.ref_name, '-') }}
         uses: actions/setup-node@v7
         with:
-          node-version: 20
+          node-version: 24
           registry-url: https://registry.npmjs.org
 
       # npm Trusted Publishing: the npm CLI (>= 11.5.1) auto-exchanges the
@@ -168,6 +168,9 @@ jobs:
       # short-lived publish credential. No NPM_TOKEN env var needed.
       # Configured on npmjs.com -> Package settings -> Publishing access ->
       # Trusted publisher = nicholasbester/clickup-cli, workflow build.yml.
+      # NOTE: npm@latest's engine floor tracks upstream — npm 12 requires
+      # Node >= 22, which is why node-version above must stay a current LTS
+      # (Node 20 + npm 12 broke every release v0.15.0-v0.15.2, issue #105).
       - name: Upgrade npm to a Trusted-Publishing-capable version
         if: ${{ !contains(github.ref_name, '-') }}
         run: npm install -g npm@latest
@@ -190,7 +193,7 @@ jobs:
         if: ${{ !contains(github.ref_name, '-') }}
         uses: actions/setup-node@v7
         with:
-          node-version: 20
+          node-version: 24
           registry-url: https://npm.pkg.github.com
           scope: '@nicholasbester'
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -169,8 +169,11 @@ jobs:
       # Configured on npmjs.com -> Package settings -> Publishing access ->
       # Trusted publisher = nicholasbester/clickup-cli, workflow build.yml.
       # NOTE: npm@latest's engine floor tracks upstream — npm 12 requires
-      # Node >= 22, which is why node-version above must stay a current LTS
-      # (Node 20 + npm 12 broke every release v0.15.0-v0.15.2, issue #105).
+      # Node >= 22, so node-version above must stay inside npm@latest's
+      # engine range (Node 20 + npm 12 broke every release v0.15.0-v0.15.2,
+      # issue #105). Node 24's bundled npm (>= 11.17) already meets the
+      # 11.5.1 Trusted-Publishing floor; this step only tracks latest for
+      # OIDC-flow fixes.
       - name: Upgrade npm to a Trusted-Publishing-capable version
         if: ${{ !contains(github.ref_name, '-') }}
         run: npm install -g npm@latest


### PR DESCRIPTION
Fixes #105.

npm 12 (current `latest`) requires Node `^22.22.2 || ^24.15.0 || >=26`; the release job pinned Node 20, so the `npm install -g npm@latest` step (needed for OIDC Trusted Publishing) has failed on every tag since npm 12 shipped — killing npm publish, the Homebrew formula update (later step, same job), and the AUR publish (workflow_run success gate) for v0.15.0–v0.15.2. crates.io and GitHub releases were unaffected (earlier steps).

This bumps both `setup-node` blocks to Node 24 (active LTS, satisfies npm 12) and adds a comment coupling the pin to npm@latest's engine floor so the next drift is diagnosable at the workflow.

Verification is inherently release-time only (these steps run on `v*` tags): the next tag is the real test, and I'll watch the pipeline job-by-job.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MnsYXHkHyZWDc8YrBdocsd