### PR TITLE
release: v0.15.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.15.3] - 2026-08-14
+
+### Fixed
+- MCP: `clickup_member_list` now routes `task_id` through the same `resolve_task` handling as every other task-scoped MCP tool (#101). Previously it passed the ID raw into `/v2/task/{id}/member`, so custom-format IDs (`PROJ-42`) drew ClickUp's misleading 401 "Team not authorized" and explicit `CU-` prefixes were not stripped. `clickup_guest_share_task`/`unshare_task` keep taking raw IDs, matching their CLI twins.
+- Release pipeline: the npm publish step failed on every tag since npm 12 raised its engine floor to Node ≥ 22 while the release job pinned Node 20 (#105). As a result, **versions 0.15.0–0.15.2 never reached npm, Homebrew, or AUR** — those channels jump from 0.14.0 directly to this release. crates.io and the GitHub release binaries were published normally for all versions. The release job now runs Node 24.
+
 ### Fixed
 - MCP: `clickup_member_list` now routes `task_id` through the same `resolve_task` handling as every other task-scoped MCP tool (#101). Previously it passed the ID raw into `/v2/task/{id}/member`, so custom-format IDs (`PROJ-42`) drew ClickUp's misleading 401 "Team not authorized" and explicit `CU-` prefixes were not stripped. `clickup_guest_share_task`/`unshare_task` keep taking raw IDs, matching their CLI twins.
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -276,7 +276,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "clickup-cli"
-version = "0.15.2"
+version = "0.15.3"
 dependencies = [
  "assert_cmd",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "clickup-cli"
-version = "0.15.2"
+version = "0.15.3"
 edition = "2021"
 rust-version = "1.88"
 description = "CLI for the ClickUp API, optimized for AI agents"

--- a/npm/package.json
+++ b/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nick.bester/clickup-cli",
-  "version": "0.15.2",
+  "version": "0.15.3",
   "description": "CLI for the ClickUp API, optimized for AI agents",
   "license": "Apache-2.0",
   "author": "Nick Bester <1872093+nicholasbester@users.noreply.github.com> (https://github.com/nicholasbester)",


### PR DESCRIPTION
Bump to 0.15.3 and roll CHANGELOG. Tagging v0.15.3 after merge triggers the release pipeline — the first run on the Node 24 fix (#105).

## In this release

- **Fixed:** MCP `clickup_member_list` custom-task-ID handling (#101, PR #103)
- **Fixed:** release pipeline Node 24 bump (#105, PR #106) — this tag is its first real exercise; npm/Homebrew/AUR catch up from 0.14.0 (0.15.0–0.15.2 never shipped on those channels; crates.io/GitHub releases were unaffected)

Post-tag verification plan: job-level check of the Build and Release run, then confirm npm shows 0.15.3, the Homebrew tap formula updated, and the AUR workflow ran (not skipped).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MnsYXHkHyZWDc8YrBdocsd