### PR TITLE
fix: repair Dockerfile broken since binary rename (#41) and MSRV bump

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,5 @@
+# Keep the local `docker build` context small — target/ alone can be
+# multi-GB on a dev machine. Glama/CI build from clean clones.
+target/
+npm/node_modules/
+.git/

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,31 @@
+# Guard for the Dockerfile: it is otherwise only ever built by external
+# platforms (e.g. Glama's MCP hosting), and it has silently broken twice —
+# at the binary rename (#41) and at the MSRV bump to 1.88 (see #108).
+name: Docker
+
+on:
+  pull_request:
+    paths:
+      - Dockerfile
+      - .dockerignore
+      - Cargo.toml
+      - Cargo.lock
+      - src/**
+      - .github/workflows/docker.yml
+
+jobs:
+  build:
+    name: docker build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - name: Build image
+        run: docker build -t clickup-cli-ci .
+      - name: Smoke-test CLI and MCP server
+        run: |
+          docker run --rm clickup-cli-ci --version
+          docker run --rm --entrypoint clickup-cli clickup-cli-ci --version
+          docker run --rm --entrypoint clkup clickup-cli-ci --version
+          echo '{"jsonrpc":"2.0","id":1,"method":"tools/list","params":{}}' \
+            | docker run --rm -i -e CLICKUP_TOKEN=pk_test -e CLICKUP_WORKSPACE=99 clickup-cli-ci \
+            | grep -q '"tools"'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- The repo Dockerfile had been broken since the binary rename in #41: it copied a binary named `clickup` that no longer exists (the crate ships `clickup-cli`/`clkup`), and its `rust:1.87-slim` build stage fell below the crate's MSRV once that was bumped to 1.88. This also broke Glama's hosted MCP-server build, whose inferred build spec mirrored the same wrong binary name. The build stage now major-pins `rust:1-slim-trixie` (tracks stable, stays above future MSRV bumps) with the runtime on the matching `debian:trixie-slim` (mismatched Debian suites between stages fail at runtime on glibc), builds `--bin clickup-cli`, and installs it under the image's historical command name `clickup`. Verified by building the image and driving the containerized MCP server over stdio.
+
 ## [0.15.3] - 2026-08-14
 
 ### Fixed

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,18 +1,37 @@
+# Container image for the CLI / MCP server (default CMD runs `mcp serve`,
+# JSON-RPC over stdio). MCP hosting platforms (e.g. Glama) build from this
+# file in preference to an inferred build spec.
+#
+# Run locally:
+#   docker build -t clickup-cli .
+#   docker run -i -e CLICKUP_TOKEN=pk_... -e CLICKUP_WORKSPACE=123 clickup-cli
+#   docker run -e CLICKUP_TOKEN=pk_... clickup-cli task list --list 123
+
 # Build stage
-FROM rust:1.87-slim AS builder
+# Major-pinned so the toolchain tracks stable and stays >= the crate's
+# rust-version (MSRV) in Cargo.toml. A minor pin (rust:1.87) silently fell
+# below the MSRV once it was bumped to 1.88.
+# Both stages MUST pin the same Debian suite (-trixie here): a builder on a
+# newer suite links against a newer glibc than the runtime image provides
+# (rust:1-slim on trixie/glibc 2.39 vs bookworm/glibc 2.36 fails at runtime).
+FROM rust:1-slim-trixie AS builder
 
 WORKDIR /app
 COPY Cargo.toml Cargo.lock ./
 COPY src/ src/
 
-RUN cargo build --release
+# The crate ships two identical binaries, `clickup-cli` and `clkup`
+# (renamed from `clickup` in #41); build one and install it below under
+# the historical image command name `clickup`.
+RUN cargo build --release --bin clickup-cli
 
 # Runtime stage
-FROM debian:bookworm-slim
+FROM debian:trixie-slim
 
-RUN apt-get update && apt-get install -y ca-certificates && rm -rf /var/lib/apt/lists/*
+# ca-certificates: rustls loads the system trust store for TLS to the ClickUp API.
+RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates && rm -rf /var/lib/apt/lists/*
 
-COPY --from=builder /app/target/release/clickup /usr/local/bin/clickup
+COPY --from=builder /app/target/release/clickup-cli /usr/local/bin/clickup
 
 ENTRYPOINT ["clickup"]
 CMD ["mcp", "serve"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,6 +14,7 @@
 # Both stages MUST pin the same Debian suite (-trixie here): a builder on a
 # newer suite links against a newer glibc than the runtime image provides
 # (rust:1-slim on trixie/glibc 2.39 vs bookworm/glibc 2.36 fails at runtime).
+# At the next Debian stable, bump both -trixie references together.
 FROM rust:1-slim-trixie AS builder
 
 WORKDIR /app
@@ -32,6 +33,11 @@ FROM debian:trixie-slim
 RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates && rm -rf /var/lib/apt/lists/*
 
 COPY --from=builder /app/target/release/clickup-cli /usr/local/bin/clickup
+# Hardlink the documented binary names (docs/install.md: every install
+# method ships `clickup-cli` and `clkup`); `clickup` stays the image's
+# historical entrypoint name.
+RUN ln /usr/local/bin/clickup /usr/local/bin/clickup-cli \
+    && ln /usr/local/bin/clickup /usr/local/bin/clkup
 
 ENTRYPOINT ["clickup"]
 CMD ["mcp", "serve"]


### PR DESCRIPTION
## Root cause (found while diagnosing the failing Glama MCP build)

The repo's Dockerfile has been silently broken twice over:

1. **Wrong binary name** — it still does `COPY --from=builder /app/target/release/clickup`, but #41 renamed the binaries to `clickup-cli`/`clkup`. The `cargo build` succeeds, the copy fails. Glama's AI-inferred build spec mirrored this same mistake (`cp target/release/clickup`), which is why the hosted MCP build fails with `cp: cannot stat 'target/release/clickup'`.
2. **MSRV drift** — the `rust:1.87-slim` build stage fell below the crate's `rust-version = "1.88"`.

## Fix

- Build stage `rust:1-slim-trixie`: major pin tracks stable Rust (won't fall below future MSRV bumps); suite pin matches the runtime.
- Runtime `debian:trixie-slim`: **must** be the same Debian suite as the builder — testing caught that a trixie-built binary (glibc 2.39) cannot run on bookworm (glibc 2.36). The Dockerfile now documents this constraint.
- Builds `--bin clickup-cli` explicitly; installs it under the image's historical command name `clickup`, preserving `ENTRYPOINT ["clickup"]` + overridable `CMD ["mcp", "serve"]`.

## Verification (local docker build)

- `docker run --rm <img> --version` → `clickup-cli 0.15.3`
- `echo '{"jsonrpc":"2.0","id":1,"method":"tools/list",...}' | docker run -i <img>` → valid tools list over stdio

Glama builds from the repo Dockerfile in preference to its inferred spec, so merging this should unblock the hosted MCP build on their next index pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MnsYXHkHyZWDc8YrBdocsd