### PR TITLE
fix: exit 1, not clap's default 2, on CLI usage errors (#109)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Fixed
+- CLI usage errors (unknown subcommand, unknown flag, missing required argument) now exit with code 1 — the documented "client error / bad input" code — instead of clap's default 2, which this CLI's exit-code contract reserves for auth/permission errors (401/403) (#109). Agents and scripts branching on exit codes previously misclassified every typo as an auth failure. `--help` and `--version` still print to stdout and exit 0, rendered by clap exactly as before. **Behavior change:** anything that specifically matched exit code 2 to detect malformed invocations must switch to 1.
+
+### Fixed
 - The repo Dockerfile had been broken since the binary rename in #41: it copied a binary named `clickup` that no longer exists (the crate ships `clickup-cli`/`clkup`), and its `rust:1.87-slim` build stage fell below the crate's MSRV once that was bumped to 1.88. This also broke Glama's hosted MCP-server build, whose inferred build spec mirrored the same wrong binary name. The build stage now major-pins `rust:1-slim-trixie` (tracks stable, stays above future MSRV bumps) with the runtime on the matching `debian:trixie-slim` (mismatched Debian suites between stages fail at runtime on glibc), builds `--bin clickup-cli`, and installs it under the image's historical command name `clickup`. Verified by building the image and driving the containerized MCP server over stdio.
 
 ## [0.15.3] - 2026-08-14

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,9 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Fixed
-- CLI usage errors (unknown subcommand, unknown flag, missing required argument) now exit with code 1 — the documented "client error / bad input" code — instead of clap's default 2, which this CLI's exit-code contract reserves for auth/permission errors (401/403) (#109). Agents and scripts branching on exit codes previously misclassified every typo as an auth failure. `--help` and `--version` still print to stdout and exit 0, rendered by clap exactly as before. **Behavior change:** anything that specifically matched exit code 2 to detect malformed invocations must switch to 1.
-
-### Fixed
+- CLI usage errors (unknown subcommand, unknown flag, missing required argument) now exit with code 1 — the documented "client error / bad input" code — instead of clap's default 2, which this CLI's exit-code contract reserves for auth/permission errors (401/403) (#109). Agents and scripts branching on exit codes previously misclassified every typo as an auth failure. `--help` and `--version` still print to stdout and exit 0, rendered by clap exactly as before; a bare `clickup-cli` with no subcommand shows help on stderr and exits 1 (previously 2). **Behavior change:** anything that specifically matched exit code 2 to detect malformed invocations must switch to 1.
 - The repo Dockerfile had been broken since the binary rename in #41: it copied a binary named `clickup` that no longer exists (the crate ships `clickup-cli`/`clkup`), and its `rust:1.87-slim` build stage fell below the crate's MSRV once that was bumped to 1.88. This also broke Glama's hosted MCP-server build, whose inferred build spec mirrored the same wrong binary name. The build stage now major-pins `rust:1-slim-trixie` (tracks stable, stays above future MSRV bumps) with the runtime on the matching `debian:trixie-slim` (mismatched Debian suites between stages fail at runtime on glibc), builds `--bin clickup-cli`, and installs it under the image's historical command name `clickup`. Verified by building the image and driving the containerized MCP server over stdio.
 
 ## [0.15.3] - 2026-08-14
@@ -18,9 +16,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - MCP: `clickup_member_list` now routes `task_id` through the same `resolve_task` handling as every other task-scoped MCP tool (#101). Previously it passed the ID raw into `/v2/task/{id}/member`, so custom-format IDs (`PROJ-42`) drew ClickUp's misleading 401 "Team not authorized" and explicit `CU-` prefixes were not stripped. `clickup_guest_share_task`/`unshare_task` keep taking raw IDs, matching their CLI twins.
 - Release pipeline: the npm publish step failed on every tag since npm 12 raised its engine floor to Node ≥ 22 while the release job pinned Node 20 (#105). As a result, **versions 0.15.0–0.15.2 never reached npm, Homebrew, or AUR** — those channels jump from 0.14.0 directly to this release. crates.io and the GitHub release binaries were published normally for all versions. The release job now runs Node 24.
-
-### Fixed
-- MCP: `clickup_member_list` now routes `task_id` through the same `resolve_task` handling as every other task-scoped MCP tool (#101). Previously it passed the ID raw into `/v2/task/{id}/member`, so custom-format IDs (`PROJ-42`) drew ClickUp's misleading 401 "Team not authorized" and explicit `CU-` prefixes were not stripped. `clickup_guest_share_task`/`unshare_task` keep taking raw IDs, matching their CLI twins.
 
 ## [0.15.2] - 2026-08-14
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -125,7 +125,7 @@ To limit what the server exposes, pass `--profile {all|read|safe}`, `--read-only
 ## Exit Codes
 
 - 0: success
-- 1: client error (400, bad input)
+- 1: client error (400, bad input — includes CLI usage/parse errors)
 - 2: auth/permission error (401, 403)
 - 3: not found (404)
 - 4: rate limited (429)

--- a/README.md
+++ b/README.md
@@ -427,7 +427,7 @@ clickup-cli completions powershell > clickup-cli.ps1
 | Code | Meaning |
 |------|---------|
 | 0 | Success |
-| 1 | Client error (bad input) |
+| 1 | Client error (bad input) — includes CLI usage/parse errors |
 | 2 | Auth/permission error (401, 403) |
 | 3 | Not found (404) |
 | 4 | Rate limited (429) |

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -608,7 +608,7 @@ clickup-cli mcp serve
 | Code | Meaning |
 |------|---------|
 | 0 | Success |
-| 1 | Client error (bad input, 400) |
+| 1 | Client error (bad input, 400) — includes CLI usage/parse errors |
 | 2 | Auth/permission error (401, 403) |
 | 3 | Not found (404) |
 | 4 | Rate limited (429) |

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,7 +3,19 @@ use clickup_cli::{commands, Cli, Commands};
 
 #[tokio::main]
 async fn main() {
-    let cli = Cli::parse();
+    // Cli::parse() would exit(2) on usage errors — clap's default — but the
+    // documented exit-code contract reserves 2 for auth errors (401/403) and
+    // maps bad input to 1 (issue #109). Map usage errors to 1 ourselves;
+    // --help/--version (use_stderr() == false) keep printing to stdout with
+    // exit 0, rendered by clap exactly as parse() would.
+    let cli = match Cli::try_parse() {
+        Ok(cli) => cli,
+        Err(e) => {
+            let code = if e.use_stderr() { 1 } else { 0 };
+            let _ = e.print();
+            std::process::exit(code);
+        }
+    };
     let exit_code = run(cli).await;
     std::process::exit(exit_code);
 }

--- a/tests/test_exit_codes.rs
+++ b/tests/test_exit_codes.rs
@@ -1,0 +1,67 @@
+//! Regression tests for issue #109: clap usage errors exited with clap's
+//! default code 2, which the documented exit-code contract reserves for
+//! auth/permission errors (401/403). Bad input — including unparseable
+//! invocations — is documented as exit code 1.
+
+use assert_cmd::Command;
+
+fn clickup() -> Command {
+    Command::cargo_bin("clickup-cli").unwrap()
+}
+
+#[test]
+fn unknown_subcommand_exits_1() {
+    clickup()
+        .arg("bogus-cmd")
+        .assert()
+        .code(1)
+        .stderr(predicates::str::contains("unrecognized subcommand"));
+}
+
+#[test]
+fn unknown_flag_exits_1() {
+    clickup()
+        .args(["task", "get", "--nonsense-flag", "x"])
+        .assert()
+        .code(1)
+        .stderr(predicates::str::contains("unexpected argument"));
+}
+
+#[test]
+fn missing_required_arg_exits_1() {
+    // `space get` requires an ID positional.
+    clickup()
+        .args(["space", "get"])
+        .assert()
+        .code(1)
+        .stderr(predicates::str::contains("required"));
+}
+
+#[test]
+fn help_exits_0_on_stdout() {
+    clickup()
+        .arg("--help")
+        .assert()
+        .code(0)
+        .stdout(predicates::str::contains("Usage:"));
+}
+
+#[test]
+fn version_exits_0_on_stdout() {
+    clickup()
+        .arg("--version")
+        .assert()
+        .code(0)
+        .stdout(predicates::str::contains("clickup-cli"));
+}
+
+/// The short alias binary shares main.rs and must behave identically.
+#[test]
+fn clkup_unknown_subcommand_exits_1() {
+    Command::cargo_bin("clkup")
+        .unwrap()
+        .arg("bogus-cmd")
+        .assert()
+        .code(1)
+        .stderr(predicates::str::contains("unrecognized subcommand"));
+}

--- a/tests/test_exit_codes.rs
+++ b/tests/test_exit_codes.rs
@@ -65,3 +65,13 @@ fn clkup_unknown_subcommand_exits_1() {
         .code(1)
         .stderr(predicates::str::contains("unrecognized subcommand"));
 }
+
+/// Bare invocation triggers clap's help-on-missing-subcommand kind: help
+/// text renders, but on stderr with a bad-input exit — unlike --help.
+#[test]
+fn bare_invocation_exits_1_with_help_on_stderr() {
+    clickup()
+        .assert()
+        .code(1)
+        .stderr(predicates::str::contains("Usage:"));
+}


### PR DESCRIPTION
Fixes #109.

## Root cause

`src/main.rs` used `Cli::parse()`, whose usage-error path calls clap's internal `Error::exit()` — hardcoded to exit 2. The crate's own `CliError::exit_code()` mapping (1 = bad input, 2 = auth 401/403) never applies to parse errors, so the documented contract was violated by every typo: agents branching on exit codes read `unrecognized subcommand` as an auth failure.

## Fix

`Cli::try_parse()` + explicit mapping: usage errors (`e.use_stderr()`) print via clap's own renderer to stderr and exit **1**; `--help`/`--version` print to stdout and exit **0**, byte-identical to before. One change covers both binaries (`clickup-cli` and `clkup` share `main.rs`).

**Behavior change** (noted in changelog): anything matching exit code 2 specifically for malformed invocations must switch to 1. Docs tables in CLAUDE.md and docs/commands.md now state that code 1 includes usage/parse errors.

## Testing (TDD — watched the four usage-error tests fail with code 2 first)

New `tests/test_exit_codes.rs`: unknown subcommand / unknown flag / missing required arg all exit 1 with clap's message on stderr; `--help` and `--version` exit 0 on stdout; the `clkup` alias binary behaves identically.

Full suite green (26 binaries); clippy `-D warnings` clean; fmt clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MnsYXHkHyZWDc8YrBdocsd