### PR TITLE
release: v0.15.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.15.4] - 2026-08-14
+
 ### Fixed
 - CLI usage errors (unknown subcommand, unknown flag, missing required argument) now exit with code 1 — the documented "client error / bad input" code — instead of clap's default 2, which this CLI's exit-code contract reserves for auth/permission errors (401/403) (#109). Agents and scripts branching on exit codes previously misclassified every typo as an auth failure. `--help` and `--version` still print to stdout and exit 0, rendered by clap exactly as before; a bare `clickup-cli` with no subcommand shows help on stderr and exits 1 (previously 2). **Behavior change:** anything that specifically matched exit code 2 to detect malformed invocations must switch to 1.
 - The repo Dockerfile had been broken since the binary rename in #41: it copied a binary named `clickup` that no longer exists (the crate ships `clickup-cli`/`clkup`), and its `rust:1.87-slim` build stage fell below the crate's MSRV once that was bumped to 1.88. This also broke Glama's hosted MCP-server build, whose inferred build spec mirrored the same wrong binary name. The build stage now major-pins `rust:1-slim-trixie` (tracks stable, stays above future MSRV bumps) with the runtime on the matching `debian:trixie-slim` (mismatched Debian suites between stages fail at runtime on glibc), builds `--bin clickup-cli`, and installs it under the image's historical command name `clickup`. Verified by building the image and driving the containerized MCP server over stdio.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -276,7 +276,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "clickup-cli"
-version = "0.15.3"
+version = "0.15.4"
 dependencies = [
  "assert_cmd",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "clickup-cli"
-version = "0.15.3"
+version = "0.15.4"
 edition = "2021"
 rust-version = "1.88"
 description = "CLI for the ClickUp API, optimized for AI agents"

--- a/npm/package.json
+++ b/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nick.bester/clickup-cli",
-  "version": "0.15.3",
+  "version": "0.15.4",
   "description": "CLI for the ClickUp API, optimized for AI agents",
   "license": "Apache-2.0",
   "author": "Nick Bester <1872093+nicholasbester@users.noreply.github.com> (https://github.com/nicholasbester)",


### PR DESCRIPTION
Bump to 0.15.4 and roll CHANGELOG. Tagging v0.15.4 after merge triggers the release pipeline.

## In this release

- **Fixed:** CLI usage errors exit 1 (documented bad-input code) instead of clap's default 2, which the contract reserves for auth errors (#109, PR #110). Behavior change noted in changelog.
- **Fixed:** repo Dockerfile repaired (binary rename + MSRV drift; unblocks Glama's hosted MCP build) with a new docker CI guard (#108).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MnsYXHkHyZWDc8YrBdocsd