### PR TITLE
fix: strip CU- prefixes and reject custom IDs on endpoints without custom-ID support (#104)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Fixed
-- `task move`, `task set-estimate --assignee`, `task replace-estimates`, and `list add-task`/`remove-task` — plus their MCP twins (`clickup_task_move`, `clickup_task_replace_estimates`, `clickup_list_add_task`/`remove_task`) — now strip explicit `CU-` prefixes from task IDs like every other task-scoped command (#104). Custom-format IDs (`PROJ-42`) on these operations now fail locally with an actionable message ("requires the regular task id — find it with: task get PROJ-42") instead of being sent raw: their endpoints (the v3 `home_list`/`time_estimates_by_user` routes and v2 Add/Remove Task To List) document no `custom_task_ids` support, so the previous behavior was a guaranteed, confusing upstream error.
+- `task move`, `task set-estimate --assignee`, `task replace-estimates`, and `list add-task`/`remove-task` — plus their MCP twins (`clickup_task_move`, `clickup_task_replace_estimates`, `clickup_list_add_task`/`remove_task`) — now strip explicit `CU-` prefixes from task IDs like other task-scoped commands (`task link`/`unlink` keep passing IDs verbatim, as before) (#104). The MCP `clickup_task_set_estimate` tool's `user_id` branch (the same undocumented v3 endpoint) gets the identical guard. Custom-format IDs (`PROJ-42`) on these operations now fail locally with an actionable message ("requires the regular task id — find it with: task get PROJ-42") instead of being sent raw: their endpoints (the v3 `home_list`/`time_estimates_by_user` routes and v2 Add/Remove Task To List) document no `custom_task_ids` support, so the previous behavior was a confusing upstream error.
 
 ## [0.15.4] - 2026-08-14
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- `task move`, `task set-estimate --assignee`, `task replace-estimates`, and `list add-task`/`remove-task` — plus their MCP twins (`clickup_task_move`, `clickup_task_replace_estimates`, `clickup_list_add_task`/`remove_task`) — now strip explicit `CU-` prefixes from task IDs like every other task-scoped command (#104). Custom-format IDs (`PROJ-42`) on these operations now fail locally with an actionable message ("requires the regular task id — find it with: task get PROJ-42") instead of being sent raw: their endpoints (the v3 `home_list`/`time_estimates_by_user` routes and v2 Add/Remove Task To List) document no `custom_task_ids` support, so the previous behavior was a guaranteed, confusing upstream error.
+
 ## [0.15.4] - 2026-08-14
 
 ### Fixed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -137,6 +137,7 @@ To limit what the server exposes, pass `--profile {all|read|safe}`, `--read-only
 - All timestamps are Unix milliseconds
 - Priority: 1=Urgent, 2=High, 3=Normal, 4=Low
 - task_count on folders is a string, not integer
+- Custom task IDs (`PROJ-42`) are NOT accepted by `task move`, `task set-estimate --assignee`, `task replace-estimates`, or `list add-task`/`remove-task` (their endpoints have no custom-ID support) — these fail locally with guidance; pass the regular task id instead
 - v3 endpoints (chat, docs, audit logs, ACLs, attachments) use cursor pagination
 - Tag create uses tag_fg/tag_bg, tag update uses fg_color/bg_color (API inconsistency)
 - Webhook update/delete use /v2/webhook/{id} path

--- a/src/commands/list.rs
+++ b/src/commands/list.rs
@@ -168,20 +168,34 @@ pub async fn execute(command: ListCommands, cli: &Cli) -> Result<(), CliError> {
             Ok(())
         }
         ListCommands::AddTask { list_id, task_id } => {
+            let task = crate::git::parse_task_id(&task_id);
+            if task.is_custom {
+                return Err(CliError::ClientError {
+                    message: crate::git::custom_id_unsupported(&task.raw, "list add-task"),
+                    status: 0,
+                });
+            }
             client
                 .post(
-                    &format!("/v2/list/{}/task/{}", list_id, task_id),
+                    &format!("/v2/list/{}/task/{}", list_id, task.id),
                     &serde_json::json!({}),
                 )
                 .await?;
-            output.print_message(&format!("Task {} added to list {}", task_id, list_id));
+            output.print_message(&format!("Task {} added to list {}", task.raw, list_id));
             Ok(())
         }
         ListCommands::RemoveTask { list_id, task_id } => {
+            let task = crate::git::parse_task_id(&task_id);
+            if task.is_custom {
+                return Err(CliError::ClientError {
+                    message: crate::git::custom_id_unsupported(&task.raw, "list remove-task"),
+                    status: 0,
+                });
+            }
             client
-                .delete(&format!("/v2/list/{}/task/{}", list_id, task_id))
+                .delete(&format!("/v2/list/{}/task/{}", list_id, task.id))
                 .await?;
-            output.print_message(&format!("Task {} removed from list {}", task_id, list_id));
+            output.print_message(&format!("Task {} removed from list {}", task.raw, list_id));
             Ok(())
         }
     }

--- a/src/commands/list.rs
+++ b/src/commands/list.rs
@@ -171,7 +171,11 @@ pub async fn execute(command: ListCommands, cli: &Cli) -> Result<(), CliError> {
             let task = crate::git::parse_task_id(&task_id);
             if task.is_custom {
                 return Err(CliError::ClientError {
-                    message: crate::git::custom_id_unsupported(&task.raw, "list add-task"),
+                    message: crate::git::custom_id_unsupported(
+                        &task.raw,
+                        "list add-task",
+                        "task get",
+                    ),
                     status: 0,
                 });
             }
@@ -188,7 +192,11 @@ pub async fn execute(command: ListCommands, cli: &Cli) -> Result<(), CliError> {
             let task = crate::git::parse_task_id(&task_id);
             if task.is_custom {
                 return Err(CliError::ClientError {
-                    message: crate::git::custom_id_unsupported(&task.raw, "list remove-task"),
+                    message: crate::git::custom_id_unsupported(
+                        &task.raw,
+                        "list remove-task",
+                        "task get",
+                    ),
                     status: 0,
                 });
             }

--- a/src/commands/task.rs
+++ b/src/commands/task.rs
@@ -652,7 +652,7 @@ pub async fn execute(command: TaskCommands, cli: &Cli) -> Result<(), CliError> {
             let task = git::require_task(cli, id.as_deref(), true)?;
             if task.is_custom {
                 return Err(CliError::ClientError {
-                    message: git::custom_id_unsupported(&task.raw, "task move"),
+                    message: git::custom_id_unsupported(&task.raw, "task move", "task get"),
                     status: 0,
                 });
             }
@@ -680,6 +680,7 @@ pub async fn execute(command: TaskCommands, cli: &Cli) -> Result<(), CliError> {
                         message: git::custom_id_unsupported(
                             &task.raw,
                             "task set-estimate --assignee",
+                            "task get",
                         ),
                         status: 0,
                     });
@@ -720,7 +721,11 @@ pub async fn execute(command: TaskCommands, cli: &Cli) -> Result<(), CliError> {
             let task = git::require_task(cli, id.as_deref(), true)?;
             if task.is_custom {
                 return Err(CliError::ClientError {
-                    message: git::custom_id_unsupported(&task.raw, "task replace-estimates"),
+                    message: git::custom_id_unsupported(
+                        &task.raw,
+                        "task replace-estimates",
+                        "task get",
+                    ),
                     status: 0,
                 });
             }

--- a/src/commands/task.rs
+++ b/src/commands/task.rs
@@ -650,6 +650,12 @@ pub async fn execute(command: TaskCommands, cli: &Cli) -> Result<(), CliError> {
         }
         TaskCommands::Move { id, list } => {
             let task = git::require_task(cli, id.as_deref(), true)?;
+            if task.is_custom {
+                return Err(CliError::ClientError {
+                    message: git::custom_id_unsupported(&task.raw, "task move"),
+                    status: 0,
+                });
+            }
             let ws_id = resolve_workspace(cli)?;
             client
                 .put(
@@ -666,6 +672,18 @@ pub async fn execute(command: TaskCommands, cli: &Cli) -> Result<(), CliError> {
         TaskCommands::SetEstimate { id, assignee, time } => {
             let task = git::require_task(cli, id.as_deref(), true)?;
             let resp = if let Some(assignee) = assignee {
+                // Per-user estimates use an undocumented v3 endpoint with no
+                // custom-ID support; the flag-less v2 branch below handles
+                // custom IDs via custom_task_query.
+                if task.is_custom {
+                    return Err(CliError::ClientError {
+                        message: git::custom_id_unsupported(
+                            &task.raw,
+                            "task set-estimate --assignee",
+                        ),
+                        status: 0,
+                    });
+                }
                 let ws_id = resolve_workspace(cli)?;
                 let body = serde_json::json!({
                     "time_estimates": [{"user_id": assignee, "time_estimate": time}]
@@ -700,6 +718,12 @@ pub async fn execute(command: TaskCommands, cli: &Cli) -> Result<(), CliError> {
             ..
         } => {
             let task = git::require_task(cli, id.as_deref(), true)?;
+            if task.is_custom {
+                return Err(CliError::ClientError {
+                    message: git::custom_id_unsupported(&task.raw, "task replace-estimates"),
+                    status: 0,
+                });
+            }
             let ws_id = resolve_workspace(cli)?;
 
             // ClickUp's spec for this endpoint:

--- a/src/git.rs
+++ b/src/git.rs
@@ -180,12 +180,14 @@ pub fn parse_task_id(arg: &str) -> ResolvedTask {
 
 /// Error message for operations whose endpoints have no documented
 /// `custom_task_ids` support (issue #104): sending a custom-format ID raw
-/// is a guaranteed, confusing upstream failure, so callers reject it
-/// locally with this guidance instead.
-pub fn custom_id_unsupported(raw: &str, operation: &str) -> String {
+/// produces a confusing upstream failure, so callers reject it locally
+/// with this guidance instead. `lookup` names the surface-appropriate way
+/// to obtain the regular ID (`"task get"` for the CLI,
+/// `"clickup_task_get"` for MCP).
+pub fn custom_id_unsupported(raw: &str, operation: &str, lookup: &str) -> String {
     format!(
         "'{raw}' is a custom task ID, but {operation} requires the regular task id \
-         (its endpoint has no custom-ID support) — find it with: task get {raw}"
+         (its endpoint has no custom-ID support) — find it with: {lookup} {raw}"
     )
 }
 

--- a/src/git.rs
+++ b/src/git.rs
@@ -178,6 +178,17 @@ pub fn parse_task_id(arg: &str) -> ResolvedTask {
     }
 }
 
+/// Error message for operations whose endpoints have no documented
+/// `custom_task_ids` support (issue #104): sending a custom-format ID raw
+/// is a guaranteed, confusing upstream failure, so callers reject it
+/// locally with this guidance instead.
+pub fn custom_id_unsupported(raw: &str, operation: &str) -> String {
+    format!(
+        "'{raw}' is a custom task ID, but {operation} requires the regular task id \
+         (its endpoint has no custom-ID support) — find it with: task get {raw}"
+    )
+}
+
 /// Is branch detection enabled? Checks `CLICKUP_GIT_DETECT=0` env override,
 /// then `[git] enabled` in config. Defaults to true.
 fn detect_enabled() -> bool {

--- a/src/mcp.rs
+++ b/src/mcp.rs
@@ -3309,6 +3309,7 @@ async fn dispatch_tool(
                 return Err(git::custom_id_unsupported(
                     &task.raw,
                     "clickup_list_add_task",
+                    "clickup_task_get",
                 ));
             }
             client
@@ -3318,7 +3319,7 @@ async fn dispatch_tool(
                 )
                 .await
                 .map_err(|e| e.to_string())?;
-            Ok(json!({"message": format!("Task {} added to list {}", task.raw, list_id)}))
+            Ok(json!({"message": format!("Task {} added to list {}", task.id, list_id)}))
         }
 
         "clickup_list_remove_task" => {
@@ -3336,13 +3337,14 @@ async fn dispatch_tool(
                 return Err(git::custom_id_unsupported(
                     &task.raw,
                     "clickup_list_remove_task",
+                    "clickup_task_get",
                 ));
             }
             client
                 .delete(&format!("/v2/list/{}/task/{}", list_id, task.id))
                 .await
                 .map_err(|e| e.to_string())?;
-            Ok(json!({"message": format!("Task {} removed from list {}", task.raw, list_id)}))
+            Ok(json!({"message": format!("Task {} removed from list {}", task.id, list_id)}))
         }
 
         "clickup_comment_update" => {
@@ -4461,7 +4463,11 @@ async fn dispatch_tool(
             // (issue #104): strip CU- prefixes, reject custom-format IDs.
             let task = git::parse_task_id(raw);
             if task.is_custom {
-                return Err(git::custom_id_unsupported(&task.raw, "clickup_task_move"));
+                return Err(git::custom_id_unsupported(
+                    &task.raw,
+                    "clickup_task_move",
+                    "clickup_task_get",
+                ));
             }
             let task_id = task.id;
             let list_id = args
@@ -4492,6 +4498,16 @@ async fn dispatch_tool(
                 .ok_or("Missing required parameter: time_estimate")?;
 
             if let Some(user_id) = user_id {
+                // The v3 per-user endpoint has no documented custom-ID
+                // support (issue #104); the flag-less v2 branch below keeps
+                // it via the query fragment.
+                if custom_query.is_some() {
+                    return Err(git::custom_id_unsupported(
+                        &task_id,
+                        "clickup_task_set_estimate with user_id",
+                        "clickup_task_get",
+                    ));
+                }
                 let team_id = resolve_workspace(args)?;
                 let body = json!({"time_estimates": [{"user_id": user_id, "time_estimate": time_estimate}]});
                 client
@@ -4527,6 +4543,7 @@ async fn dispatch_tool(
                 return Err(git::custom_id_unsupported(
                     &task.raw,
                     "clickup_task_replace_estimates",
+                    "clickup_task_get",
                 ));
             }
             let task_id = task.id;

--- a/src/mcp.rs
+++ b/src/mcp.rs
@@ -3298,18 +3298,27 @@ async fn dispatch_tool(
                 .get("list_id")
                 .and_then(|v| v.as_str())
                 .ok_or("Missing required parameter: list_id")?;
-            let task_id = args
+            let raw = args
                 .get("task_id")
                 .and_then(|v| v.as_str())
                 .ok_or("Missing required parameter: task_id")?;
+            // Add Task To List documents no query params, so no custom-ID
+            // support (issue #104): strip CU-, reject custom-format IDs.
+            let task = git::parse_task_id(raw);
+            if task.is_custom {
+                return Err(git::custom_id_unsupported(
+                    &task.raw,
+                    "clickup_list_add_task",
+                ));
+            }
             client
                 .post(
-                    &format!("/v2/list/{}/task/{}", list_id, task_id),
+                    &format!("/v2/list/{}/task/{}", list_id, task.id),
                     &json!({}),
                 )
                 .await
                 .map_err(|e| e.to_string())?;
-            Ok(json!({"message": format!("Task {} added to list {}", task_id, list_id)}))
+            Ok(json!({"message": format!("Task {} added to list {}", task.raw, list_id)}))
         }
 
         "clickup_list_remove_task" => {
@@ -3317,15 +3326,23 @@ async fn dispatch_tool(
                 .get("list_id")
                 .and_then(|v| v.as_str())
                 .ok_or("Missing required parameter: list_id")?;
-            let task_id = args
+            let raw = args
                 .get("task_id")
                 .and_then(|v| v.as_str())
                 .ok_or("Missing required parameter: task_id")?;
+            // Same contract as clickup_list_add_task (issue #104).
+            let task = git::parse_task_id(raw);
+            if task.is_custom {
+                return Err(git::custom_id_unsupported(
+                    &task.raw,
+                    "clickup_list_remove_task",
+                ));
+            }
             client
-                .delete(&format!("/v2/list/{}/task/{}", list_id, task_id))
+                .delete(&format!("/v2/list/{}/task/{}", list_id, task.id))
                 .await
                 .map_err(|e| e.to_string())?;
-            Ok(json!({"message": format!("Task {} removed from list {}", task_id, list_id)}))
+            Ok(json!({"message": format!("Task {} removed from list {}", task.raw, list_id)}))
         }
 
         "clickup_comment_update" => {
@@ -4436,10 +4453,17 @@ async fn dispatch_tool(
 
         "clickup_task_move" => {
             let team_id = resolve_workspace(args)?;
-            let task_id = args
+            let raw = args
                 .get("task_id")
                 .and_then(|v| v.as_str())
                 .ok_or("Missing required parameter: task_id")?;
+            // The v3 home_list endpoint has no documented custom-ID support
+            // (issue #104): strip CU- prefixes, reject custom-format IDs.
+            let task = git::parse_task_id(raw);
+            if task.is_custom {
+                return Err(git::custom_id_unsupported(&task.raw, "clickup_task_move"));
+            }
+            let task_id = task.id;
             let list_id = args
                 .get("list_id")
                 .and_then(|v| v.as_str())
@@ -4493,10 +4517,19 @@ async fn dispatch_tool(
 
         "clickup_task_replace_estimates" => {
             let team_id = resolve_workspace(args)?;
-            let task_id = args
+            let raw = args
                 .get("task_id")
                 .and_then(|v| v.as_str())
                 .ok_or("Missing required parameter: task_id")?;
+            // v3 endpoint, no documented custom-ID support (issue #104).
+            let task = git::parse_task_id(raw);
+            if task.is_custom {
+                return Err(git::custom_id_unsupported(
+                    &task.raw,
+                    "clickup_task_replace_estimates",
+                ));
+            }
+            let task_id = task.id;
             // ClickUp's spec body is an ARRAY of {assignee, time}.
             // The previous shape {time_estimates: [{user_id, time_estimate}]}
             // had the wrong field names and the wrong wrapping, and it only

--- a/tests/test_raw_task_id_sites.rs
+++ b/tests/test_raw_task_id_sites.rs
@@ -1,0 +1,214 @@
+//! Regression tests for issue #104: `task move`, `task set-estimate`/
+//! `replace-estimates` (v3 endpoints), and `list add-task`/`remove-task`
+//! passed task IDs through without `CU-` stripping, and silently sent
+//! custom-format IDs (`PROJ-42`) to endpoints that do not document
+//! `custom_task_ids` support — a guaranteed, confusing upstream failure.
+//! Now: `CU-` prefixes are stripped everywhere, and custom-format IDs fail
+//! locally with an actionable message naming the regular-ID workaround.
+
+use assert_cmd::Command;
+use std::path::Path;
+use tempfile::TempDir;
+use wiremock::matchers::{method, path as path_matcher};
+use wiremock::{Mock, MockServer, ResponseTemplate};
+
+fn clickup(dir: &Path, server: &MockServer) -> Command {
+    let mut cmd = Command::cargo_bin("clickup-cli").unwrap();
+    cmd.current_dir(dir)
+        .env("CLICKUP_API_URL", server.uri())
+        .env("CLICKUP_TOKEN", "pk_test")
+        .env("CLICKUP_WORKSPACE", "99")
+        .env("CLICKUP_GIT_DETECT", "0")
+        .env_remove("CLICKUP_TASK_ID");
+    cmd
+}
+
+fn mcp_serve(dir: &Path, server: &MockServer) -> Command {
+    let mut cmd = Command::cargo_bin("clickup-cli").unwrap();
+    cmd.current_dir(dir)
+        .args(["mcp", "serve"])
+        .env("CLICKUP_API_URL", server.uri())
+        .env("CLICKUP_TOKEN", "pk_test")
+        .env("CLICKUP_WORKSPACE", "99")
+        .env_remove("CLICKUP_GIT_DETECT")
+        .env_remove("CLICKUP_TASK_ID");
+    cmd
+}
+
+fn rpc_call(tool: &str, arguments: serde_json::Value) -> String {
+    serde_json::json!({
+        "jsonrpc": "2.0",
+        "id": 1,
+        "method": "tools/call",
+        "params": {"name": tool, "arguments": arguments}
+    })
+    .to_string()
+        + "\n"
+}
+
+// ---------- CU- stripping ----------
+
+#[tokio::test]
+async fn cli_list_add_task_strips_cu_prefix() {
+    let dir = TempDir::new().unwrap();
+    let server = MockServer::start().await;
+
+    Mock::given(method("POST"))
+        .and(path_matcher("/v2/list/9/task/abc123"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({})))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    clickup(dir.path(), &server)
+        .args(["list", "add-task", "9", "CU-abc123"])
+        .assert()
+        .success();
+}
+
+#[tokio::test]
+async fn cli_list_remove_task_strips_cu_prefix() {
+    let dir = TempDir::new().unwrap();
+    let server = MockServer::start().await;
+
+    Mock::given(method("DELETE"))
+        .and(path_matcher("/v2/list/9/task/abc123"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({})))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    clickup(dir.path(), &server)
+        .args(["list", "remove-task", "9", "CU-abc123"])
+        .assert()
+        .success();
+}
+
+#[tokio::test]
+async fn mcp_task_move_strips_cu_prefix() {
+    let dir = TempDir::new().unwrap();
+    let server = MockServer::start().await;
+
+    Mock::given(method("PUT"))
+        .and(path_matcher("/v3/workspaces/99/tasks/abc123/home_list/9"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({})))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    mcp_serve(dir.path(), &server)
+        .write_stdin(rpc_call(
+            "clickup_task_move",
+            serde_json::json!({"task_id": "CU-abc123", "list_id": "9"}),
+        ))
+        .assert()
+        .success();
+}
+
+#[tokio::test]
+async fn mcp_list_add_task_strips_cu_prefix() {
+    let dir = TempDir::new().unwrap();
+    let server = MockServer::start().await;
+
+    Mock::given(method("POST"))
+        .and(path_matcher("/v2/list/9/task/abc123"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({})))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    mcp_serve(dir.path(), &server)
+        .write_stdin(rpc_call(
+            "clickup_list_add_task",
+            serde_json::json!({"list_id": "9", "task_id": "CU-abc123"}),
+        ))
+        .assert()
+        .success();
+}
+
+// ---------- custom-format IDs fail locally with guidance ----------
+
+#[tokio::test]
+async fn cli_task_move_rejects_custom_id_locally() {
+    let dir = TempDir::new().unwrap();
+    let server = MockServer::start().await;
+    // No mocks: the CLI must not send any request.
+
+    Mock::given(method("PUT"))
+        .respond_with(ResponseTemplate::new(500))
+        .expect(0)
+        .mount(&server)
+        .await;
+
+    clickup(dir.path(), &server)
+        .args(["task", "move", "PROJ-42", "--list", "9"])
+        .assert()
+        .code(1)
+        .stderr(predicates::str::contains("requires the regular task id"))
+        .stderr(predicates::str::contains("task get"));
+}
+
+#[tokio::test]
+async fn cli_list_add_task_rejects_custom_id_locally() {
+    let dir = TempDir::new().unwrap();
+    let server = MockServer::start().await;
+
+    Mock::given(method("POST"))
+        .respond_with(ResponseTemplate::new(500))
+        .expect(0)
+        .mount(&server)
+        .await;
+
+    clickup(dir.path(), &server)
+        .args(["list", "add-task", "9", "PROJ-42"])
+        .assert()
+        .code(1)
+        .stderr(predicates::str::contains("requires the regular task id"));
+}
+
+#[tokio::test]
+async fn mcp_task_move_rejects_custom_id_locally() {
+    let dir = TempDir::new().unwrap();
+    let server = MockServer::start().await;
+    // The MCP protocol reports tool errors in-band; the process exits 0.
+    // The error text must appear in the response and no HTTP call be made.
+
+    mcp_serve(dir.path(), &server)
+        .write_stdin(rpc_call(
+            "clickup_task_move",
+            serde_json::json!({"task_id": "PROJ-42", "list_id": "9"}),
+        ))
+        .assert()
+        .success()
+        .stdout(predicates::str::contains("requires the regular task id"));
+}
+
+#[tokio::test]
+async fn mcp_task_replace_estimates_rejects_custom_id_locally() {
+    let dir = TempDir::new().unwrap();
+    let server = MockServer::start().await;
+
+    mcp_serve(dir.path(), &server)
+        .write_stdin(rpc_call(
+            "clickup_task_replace_estimates",
+            serde_json::json!({"task_id": "PROJ-42", "estimates": [{"assignee": 1, "time": 60000}]}),
+        ))
+        .assert()
+        .success()
+        .stdout(predicates::str::contains("requires the regular task id"));
+}
+
+#[tokio::test]
+async fn mcp_list_remove_task_rejects_custom_id_locally() {
+    let dir = TempDir::new().unwrap();
+    let server = MockServer::start().await;
+
+    mcp_serve(dir.path(), &server)
+        .write_stdin(rpc_call(
+            "clickup_list_remove_task",
+            serde_json::json!({"list_id": "9", "task_id": "PROJ-42"}),
+        ))
+        .assert()
+        .success()
+        .stdout(predicates::str::contains("requires the regular task id"));
+}

--- a/tests/test_raw_task_id_sites.rs
+++ b/tests/test_raw_task_id_sites.rs
@@ -212,3 +212,113 @@ async fn mcp_list_remove_task_rejects_custom_id_locally() {
         .success()
         .stdout(predicates::str::contains("requires the regular task id"));
 }
+
+#[tokio::test]
+async fn cli_task_move_strips_cu_prefix() {
+    let dir = TempDir::new().unwrap();
+    let server = MockServer::start().await;
+
+    Mock::given(method("PUT"))
+        .and(path_matcher("/v3/workspaces/99/tasks/abc123/home_list/9"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({})))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    clickup(dir.path(), &server)
+        .args(["task", "move", "CU-abc123", "--list", "9"])
+        .assert()
+        .success();
+}
+
+#[tokio::test]
+async fn cli_set_estimate_assignee_rejects_custom_id_locally() {
+    let dir = TempDir::new().unwrap();
+    let server = MockServer::start().await;
+
+    Mock::given(method("PATCH"))
+        .respond_with(ResponseTemplate::new(500))
+        .expect(0)
+        .mount(&server)
+        .await;
+
+    clickup(dir.path(), &server)
+        .args([
+            "task",
+            "set-estimate",
+            "--id",
+            "PROJ-42",
+            "--assignee",
+            "1",
+            "--time",
+            "60000",
+        ])
+        .assert()
+        .code(1)
+        .stderr(predicates::str::contains("requires the regular task id"));
+}
+
+#[tokio::test]
+async fn cli_replace_estimates_rejects_custom_id_locally() {
+    let dir = TempDir::new().unwrap();
+    let server = MockServer::start().await;
+
+    Mock::given(method("PUT"))
+        .respond_with(ResponseTemplate::new(500))
+        .expect(0)
+        .mount(&server)
+        .await;
+
+    clickup(dir.path(), &server)
+        .args([
+            "task",
+            "replace-estimates",
+            "--id",
+            "PROJ-42",
+            "--estimate",
+            "1:60000",
+        ])
+        .assert()
+        .code(1)
+        .stderr(predicates::str::contains("requires the regular task id"));
+}
+
+/// The flag-less set-estimate path (v2, custom-ID capable) must keep
+/// working for custom IDs — the deliberately preserved branch.
+#[tokio::test]
+async fn cli_set_estimate_flagless_custom_id_still_works() {
+    let dir = TempDir::new().unwrap();
+    let server = MockServer::start().await;
+
+    Mock::given(method("PUT"))
+        .and(path_matcher("/v2/task/PROJ-42"))
+        .and(wiremock::matchers::query_param("custom_task_ids", "true"))
+        .and(wiremock::matchers::query_param("team_id", "99"))
+        .respond_with(
+            ResponseTemplate::new(200)
+                .set_body_json(serde_json::json!({"id": "abc123", "name": "t"})),
+        )
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    clickup(dir.path(), &server)
+        .args(["task", "set-estimate", "--id", "PROJ-42", "--time", "60000"])
+        .assert()
+        .success();
+}
+
+#[tokio::test]
+async fn mcp_set_estimate_user_id_rejects_custom_id_locally() {
+    let dir = TempDir::new().unwrap();
+    let server = MockServer::start().await;
+
+    mcp_serve(dir.path(), &server)
+        .write_stdin(rpc_call(
+            "clickup_task_set_estimate",
+            serde_json::json!({"task_id": "PROJ-42", "user_id": 1, "time_estimate": 60000}),
+        ))
+        .assert()
+        .success()
+        .stdout(predicates::str::contains("requires the regular task id"));
+}


### PR DESCRIPTION
Fixes #104.

## The open question in the issue, answered

Whether these endpoints accept `custom_task_ids` was unverified. Checked against ClickUp's docs: [Add Task To List](https://developer.clickup.com/reference/addtasktolist) documents **path parameters only** (no query params at all), and the v3 `home_list`/`time_estimates_by_user` routes are undocumented. So none of the four operations can legitimately claim custom-ID support.

## Fix (7 sites: 3 CLI + 4 MCP)

- **`CU-` stripping everywhere** via the existing `parse_task_id` — pure normalization, `CU-abc123` ≡ `abc123`.
- **Custom-format IDs fail locally** with `'PROJ-42' is a custom task ID, but <operation> requires the regular task id (its endpoint has no custom-ID support) — find it with: task get PROJ-42`. A raw custom ID cannot resolve upstream without the (unsupported) query pair, so the previous behavior was a guaranteed confusing API error; local rejection with guidance mirrors the no-workspace precedent from #100. Message lives in one shared helper (`git::custom_id_unsupported`).
- CLI `task set-estimate`: only the v3 `--assignee` branch rejects; the flag-less v2 branch keeps full custom-ID support via `custom_task_query`.
- CLAUDE.md notes the unsupported set so agents pass regular IDs up front.

## Testing (TDD — 8 tests watched failing first; one initial false-pass was caught and hardened)

New `tests/test_raw_task_id_sites.rs` (9 tests, wiremock + MCP stdio): CU- stripping proven by mocks that only match the stripped path (`expect(1)`); local rejection proven by a distinctive message phrase plus `expect(0)` catch-all mocks asserting **no HTTP request is made**. The first draft's rejection assertion ("custom task ID") passed spuriously against the 404 hint text — tightened to the distinctive phrase before implementing.

Full suite green (27 binaries); clippy `-D warnings` (exit code checked explicitly); fmt clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MnsYXHkHyZWDc8YrBdocsd