### PR TITLE
release: v0.15.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.15.5] - 2026-08-14
+
 ### Fixed
 - `task move`, `task set-estimate --assignee`, `task replace-estimates`, and `list add-task`/`remove-task` — plus their MCP twins (`clickup_task_move`, `clickup_task_replace_estimates`, `clickup_list_add_task`/`remove_task`) — now strip explicit `CU-` prefixes from task IDs like other task-scoped commands (`task link`/`unlink` keep passing IDs verbatim, as before) (#104). The MCP `clickup_task_set_estimate` tool's `user_id` branch (the same undocumented v3 endpoint) gets the identical guard. Custom-format IDs (`PROJ-42`) on these operations now fail locally with an actionable message ("requires the regular task id — find it with: task get PROJ-42") instead of being sent raw: their endpoints (the v3 `home_list`/`time_estimates_by_user` routes and v2 Add/Remove Task To List) document no `custom_task_ids` support, so the previous behavior was a confusing upstream error.
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -276,7 +276,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "clickup-cli"
-version = "0.15.4"
+version = "0.15.5"
 dependencies = [
  "assert_cmd",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "clickup-cli"
-version = "0.15.4"
+version = "0.15.5"
 edition = "2021"
 rust-version = "1.88"
 description = "CLI for the ClickUp API, optimized for AI agents"

--- a/npm/package.json
+++ b/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nick.bester/clickup-cli",
-  "version": "0.15.4",
+  "version": "0.15.5",
   "description": "CLI for the ClickUp API, optimized for AI agents",
   "license": "Apache-2.0",
   "author": "Nick Bester <1872093+nicholasbester@users.noreply.github.com> (https://github.com/nicholasbester)",


### PR DESCRIPTION
Bump to 0.15.5 and roll CHANGELOG. Tagging v0.15.5 after merge triggers the release pipeline.

## In this release

- **Fixed:** `CU-` prefixes stripped and custom-format task IDs rejected locally (with guidance) on `task move`, `task set-estimate --assignee`, `task replace-estimates`, `list add-task`/`remove-task` and their MCP twins — endpoints without documented custom-ID support (#104, PR #112)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MnsYXHkHyZWDc8YrBdocsd