### PR TITLE
fix: satisfy new clippy collapsible-match lint in markdown_ops

### DIFF
--- a/src/markdown_ops.rs
+++ b/src/markdown_ops.rs
@@ -248,13 +248,11 @@ pub fn markdown_to_ops(text: &str) -> Vec<Value> {
                     }
                     item_task_state = None;
                 }
-                TagEnd::Paragraph => {
-                    // Inside a list item the Item end emits the terminator;
-                    // a bare paragraph terminates its own line.
-                    if list_stack.is_empty() {
-                        line_end(&mut ops, &list_stack, None, blockquote_depth);
-                        terminator_pending = false;
-                    }
+                // Inside a list item the Item end emits the terminator;
+                // a bare paragraph terminates its own line.
+                TagEnd::Paragraph if list_stack.is_empty() => {
+                    line_end(&mut ops, &list_stack, None, blockquote_depth);
+                    terminator_pending = false;
                 }
                 _ => {}
             },


### PR DESCRIPTION
Repairs main's lint job: PR #117 was merged despite a failing `lint` check (a chained merge command that didn't gate on the CI watcher's output — my process failure, now corrected). The failure itself: CI's latest-stable clippy flags `markdown_ops.rs`'s `TagEnd::Paragraph` arm as collapsible into a match guard — a lint the stale local toolchain (1.94) doesn't know. Pure refactor, behavior identical, all 18 module tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MnsYXHkHyZWDc8YrBdocsd