### PR TITLE
release: v0.16.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.16.0] - 2026-08-20
+
 ### Dependencies
 - Bumped transitive `h2` 0.4.13 → 0.4.16 to clear a new RUSTSEC advisory ("unbounded empty DATA frames") flagged by the cargo-deny CI check.
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -276,7 +276,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "clickup-cli"
-version = "0.15.5"
+version = "0.16.0"
 dependencies = [
  "assert_cmd",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "clickup-cli"
-version = "0.15.5"
+version = "0.16.0"
 edition = "2021"
 rust-version = "1.88"
 description = "CLI for the ClickUp API, optimized for AI agents"

--- a/npm/package.json
+++ b/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nick.bester/clickup-cli",
-  "version": "0.15.5",
+  "version": "0.16.0",
   "description": "CLI for the ClickUp API, optimized for AI agents",
   "license": "Apache-2.0",
   "author": "Nick Bester <1872093+nicholasbester@users.noreply.github.com> (https://github.com/nicholasbester)",


### PR DESCRIPTION
Bump to 0.16.0 and roll CHANGELOG. Tagging v0.16.0 after merge triggers the release pipeline.

## In this release

- **Added:** markdown comment support — `comment create/reply --markdown` + MCP `clickup_comment_create` `markdown` arg, via ClickUp's documented rich-comment ops (#117)
- **Added:** `--subtasks` on `task list`/`task search`, `--include-closed` on `task search`, MCP `clickup_task_list` `subtasks` arg (#115)
- **Fixed:** `task search` pagination contract implemented (`--all` was ignored); `task list` walker gains the documented 100-page cap plus two more `--all` fixes (#115)
- **Fixed:** clippy match-guard lint (#118)
- **Dependencies:** comfy-table 8.0 (#95), rust-minor-patch groups (#114), h2 RUSTSEC advisory bump (#116)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MnsYXHkHyZWDc8YrBdocsd