### PR TITLE
release: v0.17.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.17.0] - 2026-08-28
+
 ### Added
 - Comment formatting v2 (#120): the MCP `clickup_comment_reply` tool gains the `markdown` argument (parity with CLI `comment reply --markdown`); `comment update --markdown` (CLI) and a `markdown` argument on `clickup_comment_update` (MCP) — ClickUp's comment-formatting docs confirm the ops format applies to updates, un-parking the v1 out-of-scope item; and native @mentions in markdown mode: a CommonMark link with a `user:` scheme (`[@Nick](user:81618)`) becomes ClickUp's documented mention op `{"type": "tag", "user": {"id": ...}}`, which notifies the user — the link text is informational (ClickUp renders the member's real name), a non-numeric id degrades to a normal link, and styling around a mention is dropped (mention ops carry no attributes).
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -276,7 +276,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "clickup-cli"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "assert_cmd",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "clickup-cli"
-version = "0.16.0"
+version = "0.17.0"
 edition = "2021"
 rust-version = "1.88"
 description = "CLI for the ClickUp API, optimized for AI agents"

--- a/npm/package.json
+++ b/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nick.bester/clickup-cli",
-  "version": "0.16.0",
+  "version": "0.17.0",
   "description": "CLI for the ClickUp API, optimized for AI agents",
   "license": "Apache-2.0",
   "author": "Nick Bester <1872093+nicholasbester@users.noreply.github.com> (https://github.com/nicholasbester)",


### PR DESCRIPTION
Bump to 0.17.0 and roll CHANGELOG. Tagging v0.17.0 after merge triggers the release pipeline.

## In this release

- **Added:** comment formatting v2 (#120, PR #121) — `markdown` on MCP `clickup_comment_reply` (CLI parity), `comment update --markdown` (CLI + MCP), and native @mentions via the `user:` link scheme, verified against the live ClickUp API.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MnsYXHkHyZWDc8YrBdocsd