### PR TITLE
test: markdown comment shell-boundary coverage incl. real PowerShell

### DIFF
--- a/tests/test_shell_args.rs
+++ b/tests/test_shell_args.rs
@@ -80,6 +80,46 @@ fn find_powershell() -> Option<&'static str> {
     None
 }
 
+/// Markdown comment content that exercises every PowerShell-hostile
+/// character class at once: backticks (PowerShell's escape character —
+/// silently eaten in double-quoted arguments), `**` (wildcard-ish), a
+/// multiline body (the #70 splitting failure), and the `[@Name](user:N)`
+/// mention syntax. The `@file` route must deliver all of it verbatim.
+const MARKDOWN_FILE_CONTENT: &str = "**bold** with `code`\n\nping [@Nick](user:81618)\n";
+
+/// Start a mock that only returns 200 when `comment create --markdown`
+/// posts the exact ops the markdown above parses to — so a successful exit
+/// proves the markdown crossed the shell boundary intact AND was converted,
+/// backticks and mention included.
+async fn mount_markdown_comment_mock(server: &MockServer) {
+    Mock::given(method("POST"))
+        .and(path_matcher("/v2/task/t1/comment"))
+        .and(body_json(serde_json::json!({
+            "comment": [
+                {"text": "bold", "attributes": {"bold": true}},
+                {"text": " with "},
+                {"text": "code", "attributes": {"code": true}},
+                {"text": "\n"},
+                {"text": "ping "},
+                {"type": "tag", "user": {"id": 81618}},
+                {"text": "\n"}
+            ],
+            "notify_all": false
+        })))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "id": "c1"
+        })))
+        .expect(1)
+        .mount(server)
+        .await;
+}
+
+fn write_markdown_file(dir: &Path) -> std::path::PathBuf {
+    let p = dir.join("comment.md");
+    std::fs::write(&p, MARKDOWN_FILE_CONTENT).unwrap();
+    p
+}
+
 #[cfg(unix)]
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn at_file_survives_posix_shell_boundary() {
@@ -146,6 +186,72 @@ async fn at_file_survives_powershell_boundary() {
     assert!(
         out.status.success(),
         "PowerShell ({ps}) invocation failed: status={:?}\nstdout={}\nstderr={}",
+        out.status,
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr),
+    );
+}
+
+#[cfg(unix)]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn markdown_comment_at_file_survives_posix_shell_boundary() {
+    let dir = tempfile::TempDir::new().unwrap();
+    let server = MockServer::start().await;
+    mount_markdown_comment_mock(&server).await;
+    let md = write_markdown_file(dir.path());
+
+    let mut cmd = Command::new("sh");
+    with_env(&mut cmd, &server);
+    cmd.arg("-c")
+        .arg(r#""$1" comment create --task t1 --markdown --text "@$2""#)
+        .arg("sh")
+        .arg(binary())
+        .arg(&md);
+
+    let out = cmd.output().expect("failed to run sh");
+    assert!(
+        out.status.success(),
+        "sh invocation failed: status={:?}\nstdout={}\nstderr={}",
+        out.status,
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr),
+    );
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn markdown_comment_at_file_survives_powershell_boundary() {
+    let Some(ps) = find_powershell() else {
+        eprintln!("skipping: no PowerShell (powershell/pwsh) found on PATH");
+        return;
+    };
+
+    let dir = tempfile::TempDir::new().unwrap();
+    let server = MockServer::start().await;
+    mount_markdown_comment_mock(&server).await;
+    let md = write_markdown_file(dir.path());
+
+    let script = dir.path().join("invoke-md.ps1");
+    std::fs::write(
+        &script,
+        "param([string]$Bin,[string]$MdFile)\n\
+         & $Bin comment create --task t1 --markdown --text \"@$MdFile\"\n\
+         exit $LASTEXITCODE\n",
+    )
+    .unwrap();
+
+    let mut cmd = Command::new(ps);
+    with_env(&mut cmd, &server);
+    cmd.args(["-NoProfile", "-ExecutionPolicy", "Bypass", "-File"])
+        .arg(&script)
+        .arg("-Bin")
+        .arg(binary())
+        .arg("-MdFile")
+        .arg(&md);
+
+    let out = cmd.output().expect("failed to run PowerShell");
+    assert!(
+        out.status.success(),
+        "PowerShell ({ps}) markdown invocation failed: status={:?}\nstdout={}\nstderr={}",
         out.status,
         String::from_utf8_lossy(&out.stdout),
         String::from_utf8_lossy(&out.stderr),

--- a/tests/test_shell_args.rs
+++ b/tests/test_shell_args.rs
@@ -80,11 +80,16 @@ fn find_powershell() -> Option<&'static str> {
     None
 }
 
-/// Markdown comment content that exercises every PowerShell-hostile
-/// character class at once: backticks (PowerShell's escape character —
-/// silently eaten in double-quoted arguments), `**` (wildcard-ish), a
+/// Markdown comment content full of characters a user could never safely
+/// type inline in PowerShell: backticks (its escape character), `**`, a
 /// multiline body (the #70 splitting failure), and the `[@Name](user:N)`
-/// mention syntax. The `@file` route must deliver all of it verbatim.
+/// mention syntax. None of it touches the shell's argument parser — only
+/// the `@path` token does — which is exactly the property under test: the
+/// `@file` route must deliver all of it verbatim regardless of shell.
+///
+/// The trailing newline is stripped once by the `@file` read helper; the
+/// `"\n"` ops the mock expects are unrelated — `markdown_to_ops` appends a
+/// terminator op per paragraph regardless of source newlines.
 const MARKDOWN_FILE_CONTENT: &str = "**bold** with `code`\n\nping [@Nick](user:81618)\n";
 
 /// Start a mock that only returns 200 when `comment create --markdown`


### PR DESCRIPTION
## Why

The v0.17.0 markdown-comment features were unit/e2e tested and verified against the live ClickUp API, but nothing exercised them **through a real shell** — and markdown text is maximally PowerShell-hostile: backticks are PowerShell's escape character (silently eaten in double-quoted args) and multiline bodies are the exact #70 splitting failure.

## What

Two tests added to the existing `tests/test_shell_args.rs` harness (no src changes):

- `markdown_comment_at_file_survives_posix_shell_boundary` — runs everywhere unix
- `markdown_comment_at_file_survives_powershell_boundary` — runs against **real Windows PowerShell 5.1 on windows-latest**, self-skips where no PowerShell exists

Both invoke the built binary through the shell with `comment create --markdown --text "@$File"` where the file contains bold + inline backtick code + a blank-line paragraph break + a `[@Nick](user:81618)` mention, against a wiremock that only 200s on the **exact** documented ops body (bold/code attributes + tag op). A green run proves the markdown crossed the shell boundary verbatim and converted correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MnsYXHkHyZWDc8YrBdocsd